### PR TITLE
Code formatting clean up + minor edits

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -149,45 +149,47 @@ public class DesktopFolderApp : Gtk.Application {
                 string   name = file_info.get_name ();
                 File     file = File.new_for_commandline_arg (base_path + "/" + name);
                 FileType type = file.query_file_type (FileQueryInfoFlags.NONE);
+
                 if (type == FileType.DIRECTORY) {
                     totalFolders++;
-                    // maybe this is an existent already monitored folder
+
+                    // Is this folder already known about?
                     DesktopFolder.FolderManager fm = this.find_folder_by_name (name);
+
                     if (fm == null) {
-                        // we've found a directory, let's create a desktop-folder window
+                        // No, it's a new folder
                         fm = new DesktopFolder.FolderManager (this, name);
                     } else {
                         this.folders.remove (fm);
                     }
                     updated_folder_list.append (fm);
                 } else {
-                    // maybe a desktop-folder note?
                     string basename = file.get_basename ();
                     int    index    = basename.last_index_of (".", 0);
                     if (index > 0) {
                         string ext       = basename.substring (index + 1);
                         string file_name = basename.substring (0, index);
                         if (ext == DesktopFolder.NOTE_EXTENSION) {
-                            // a note!
                             totalNotes++;
-                            // maybe this is an existent already monitored folder
+
+                            // Is this note already known about?
                             DesktopFolder.NoteManager nm = this.find_note_by_name (file_name);
+
                             if (nm == null) {
-                                // debug("new note found!");
-                                // we've found a note file, let's create a note window
+                                // No, it's a new note
                                 nm = new DesktopFolder.NoteManager (this, basename.substring (0, index), file);
                             } else {
                                 this.notes.remove (nm);
                             }
                             updated_note_list.append (nm);
-                        } else if (ext == DesktopFolder.PHOTO_EXTENSION)     {
-                            // a photo
+                        } else if (ext == DesktopFolder.PHOTO_EXTENSION) {
                             totalPhotos++;
-                            // maybe this is an existent already monitored photo
+
+                            // Is this photo already known about?
                             DesktopFolder.PhotoManager pm = this.find_photo_by_name (file_name);
+
                             if (pm == null) {
-                                // debug("new note found!");
-                                // we've found a note file, let's create a note window
+                                // No, it's a new photo
                                 pm = new DesktopFolder.PhotoManager (this, basename.substring (0, index), file);
                             } else {
                                 this.photos.remove (pm);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -85,7 +85,7 @@ public class DesktopFolderApp : Gtk.Application {
             return;
         }
 
-        create_shortchut ();
+        create_shortcut ();
 
         // we need the app folder (desktop folder)
         var desktopFolder = File.new_for_path (DesktopFolderApp.get_app_folder ());
@@ -411,10 +411,10 @@ public class DesktopFolderApp : Gtk.Application {
     }
 
     /**
-     * @name create_shortchut
+     * @name create_shortcut
      * @description create a short cut SUPER-D at the system shortcuts to minimize all windows
      */
-    private static void create_shortchut () {
+    private static void create_shortcut () {
         string path                        = "/usr/bin/"; // we expect to have the command at the path
         Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.init ();
         var    shortcut                    = new Pantheon.Keyboard.Shortcuts.Shortcut (100, Gdk.ModifierType.SUPER_MASK);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -254,7 +254,7 @@ public class DesktopFolderApp : Gtk.Application {
      * @return FolderManager the Folder found or null if none
      */
     private DesktopFolder.FolderManager ? find_folder_by_name (string folder_name) {
-        for (int i = 0 ; i < this.folders.length () ; i++) {
+        for (int i = 0; i < this.folders.length (); i++) {
             DesktopFolder.FolderManager fm = this.folders.nth (i).data;
             if (fm.get_folder_name () == folder_name) {
                 return fm;
@@ -270,7 +270,7 @@ public class DesktopFolderApp : Gtk.Application {
      * @return NoteManager the Note found or null if none
      */
     private DesktopFolder.NoteManager ? find_note_by_name (string note_name) {
-        for (int i = 0 ; i < this.notes.length () ; i++) {
+        for (int i = 0; i < this.notes.length (); i++) {
             DesktopFolder.NoteManager nm = this.notes.nth (i).data;
             if (nm.get_note_name () == note_name) {
                 return nm;
@@ -286,7 +286,7 @@ public class DesktopFolderApp : Gtk.Application {
      * @return PhotoManager the Photo found or null if none
      */
     private DesktopFolder.PhotoManager ? find_photo_by_name (string photo_name) {
-        for (int i = 0 ; i < this.photos.length () ; i++) {
+        for (int i = 0; i < this.photos.length (); i++) {
             DesktopFolder.PhotoManager nm = this.photos.nth (i).data;
             if (nm.get_photo_name () == photo_name) {
                 return nm;
@@ -301,7 +301,7 @@ public class DesktopFolderApp : Gtk.Application {
      * @return bool true->yes, it is being monitored
      */
     public bool exist_manager (string folder_name) {
-        for (int i = 0 ; i < this.folders.length () ; i++) {
+        for (int i = 0; i < this.folders.length (); i++) {
             DesktopFolder.FolderManager fm = this.folders.nth (i).data;
             if (fm.get_folder_name () == folder_name) {
                 return true;
@@ -348,7 +348,7 @@ public class DesktopFolderApp : Gtk.Application {
             string ext = basename.substring (index + 1);
             if (ext == DesktopFolder.NOTE_EXTENSION) {
                 flagNote = true;
-            } else if (ext == DesktopFolder.PHOTO_EXTENSION)     {
+            } else if (ext == DesktopFolder.PHOTO_EXTENSION) {
                 flagPhoto = true;
             }
         }
@@ -368,7 +368,7 @@ public class DesktopFolderApp : Gtk.Application {
      * @description close all the folders launched
      */
     protected void clear_all () {
-        for (int i = 0 ; i < this.folders.length () ; i++) {
+        for (int i = 0; i < this.folders.length (); i++) {
             DesktopFolder.FolderManager fm = this.folders.nth (i).data;
             fm.close ();
         }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,260 +1,260 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* The Main Application
-*/
+ * @class
+ * The Main Application
+ */
 public class DesktopFolderApp : Gtk.Application {
 
     /** File Monitor of desktop folder */
-    private FileMonitor monitor=null;
+    private FileMonitor monitor = null;
 
     /** List of folder owned by the application */
-    private List<DesktopFolder.FolderManager> folders=new List<DesktopFolder.FolderManager>();
-    private List<DesktopFolder.NoteManager> notes=new List<DesktopFolder.NoteManager>();
-    private List<DesktopFolder.PhotoManager> photos=new List<DesktopFolder.PhotoManager>();
+    private List<DesktopFolder.FolderManager> folders = new List<DesktopFolder.FolderManager>();
+    private List<DesktopFolder.NoteManager> notes     = new List<DesktopFolder.NoteManager>();
+    private List<DesktopFolder.PhotoManager> photos   = new List<DesktopFolder.PhotoManager>();
 
     construct {
         /* Needed by Glib.Application */
-        this.application_id = DesktopFolder.APP_ID;  //Ensures an unique instance.
-        this.flags = ApplicationFlags.FLAGS_NONE;
+        this.application_id = DesktopFolder.APP_ID; // Ensures an unique instance.
+        this.flags          = ApplicationFlags.FLAGS_NONE;
 
         /* Needed by Granite.Application */
         /*
-        this.program_name = _(DesktopFolder.APP_TITLE);
-        this.exec_name = DesktopFolder.APP_NAME;
-        this.build_version = DesktopFolder.VERSION;
-        */
+           this.program_name = _(DesktopFolder.APP_TITLE);
+           this.exec_name = DesktopFolder.APP_NAME;
+           this.build_version = DesktopFolder.VERSION;
+         */
     }
 
     /**
-    * @constructor
-    */
+     * @constructor
+     */
     public DesktopFolderApp () {
         Object (application_id: "com.github.spheras.desktopfolder",
-        flags: ApplicationFlags.FLAGS_NONE);
+                flags : ApplicationFlags.FLAGS_NONE);
     }
 
     /**
-    * @name activate
-    * @override
-    * @description activate life cycle
-    */
+     * @name activate
+     * @override
+     * @description activate life cycle
+     */
     protected override void activate () {
         base.activate ();
-        debug("activate event");
-        //we'll init the app in the activate event
-        init();
+        debug ("activate event");
+        // we'll init the app in the activate event
+        init ();
     }
 
     /**
-    * @name startup
-    * @override
-    * @description startup life cycle
-    */
+     * @name startup
+     * @override
+     * @description startup life cycle
+     */
     public override void startup () {
         base.startup ();
-        debug("startup event");
+        debug ("startup event");
     }
 
     /**
-    * @name init
-    * @description initialization of the application
-    */
-    private void init(){
-        //only one app at a time
-        if (get_windows().length () > 0) {
-            get_windows().data.present ();
+     * @name init
+     * @description initialization of the application
+     */
+    private void init () {
+        // only one app at a time
+        if (get_windows ().length () > 0) {
+            get_windows ().data.present ();
             return;
         }
 
-        create_shortchut();
+        create_shortchut ();
 
-        //we need the app folder (desktop folder)
-        var desktopFolder = File.new_for_path (DesktopFolderApp.get_app_folder());
-        if(!desktopFolder.query_exists()){
-            DirUtils.create(DesktopFolderApp.get_app_folder(),0755);
+        // we need the app folder (desktop folder)
+        var desktopFolder = File.new_for_path (DesktopFolderApp.get_app_folder ());
+        if (!desktopFolder.query_exists ()) {
+            DirUtils.create (DesktopFolderApp.get_app_folder (), 0755);
         }
 
-        //initializing the clipboard manager
+        // initializing the clipboard manager
         DesktopFolder.Clipboard.ClipboardManager.get_for_display ();
 
-        //providing css style
+        // providing css style
         var provider = new Gtk.CssProvider ();
         provider.load_from_resource ("com/github/spheras/desktopfolder/Application.css");
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                                                  Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        //quit action
+        // quit action
         /*
-        var quit_action = new SimpleAction ("quit", null);
-        add_action (quit_action);
-        add_accelerator ("<Control>q", "app.quit", null);
-        quit_action.activate.connect (() => {
+           var quit_action = new SimpleAction ("quit", null);
+           add_action (quit_action);
+           add_accelerator ("<Control>q", "app.quit", null);
+           quit_action.activate.connect (() => {
             if (app_window != null) {
                 app_window.destroy ();
             }
-        });
-        */
+           });
+         */
 
-        //we start creating the folders found at the desktop folder
-        this.sync_folders_and_notes();
-        this.monitor_desktop();
+        // we start creating the folders found at the desktop folder
+        this.sync_folders_and_notes ();
+        this.monitor_desktop ();
     }
 
     /**
-    * @name get_app_folder
-    * @description return the path where the app search folders to be created (the desktop folder)
-    * @return string the absolute path directory
-    */
-    public static string get_app_folder (){
-        return Environment.get_home_dir ()+"/Desktop";
+     * @name get_app_folder
+     * @description return the path where the app search folders to be created (the desktop folder)
+     * @return string the absolute path directory
+     */
+    public static string get_app_folder () {
+        return Environment.get_home_dir () + "/Desktop";
     }
 
     /**
-    * @name sync_folders_and_notes
-    * @description create as many folder and note windows as the desktop folder and note founds
-    */
+     * @name sync_folders_and_notes
+     * @description create as many folder and note windows as the desktop folder and note founds
+     */
     private void sync_folders_and_notes () {
         try {
-            var base_path=DesktopFolderApp.get_app_folder();
-            var directory = File.new_for_path (base_path);
+            var base_path  = DesktopFolderApp.get_app_folder ();
+            var directory  = File.new_for_path (base_path);
             var enumerator = directory.enumerate_children (FileAttribute.STANDARD_NAME, 0);
 
             FileInfo file_info;
-            List<DesktopFolder.FolderManager> updated_folder_list=new List<DesktopFolder.FolderManager>();
-            List<DesktopFolder.NoteManager> updated_note_list=new List<DesktopFolder.NoteManager>();
-            List<DesktopFolder.PhotoManager> updated_photo_list=new List<DesktopFolder.PhotoManager>();
-            int totalFolders=0;
-            int totalNotes=0;
-            int totalPhotos=0;
+            List<DesktopFolder.FolderManager> updated_folder_list = new List<DesktopFolder.FolderManager>();
+            List<DesktopFolder.NoteManager>   updated_note_list   = new List<DesktopFolder.NoteManager>();
+            List<DesktopFolder.PhotoManager>  updated_photo_list  = new List<DesktopFolder.PhotoManager>();
+            int totalFolders = 0;
+            int totalNotes   = 0;
+            int totalPhotos  = 0;
             while ((file_info = enumerator.next_file ()) != null) {
-                string name=file_info.get_name();
-                File file = File.new_for_commandline_arg (base_path+"/"+name);
+                string   name = file_info.get_name ();
+                File     file = File.new_for_commandline_arg (base_path + "/" + name);
                 FileType type = file.query_file_type (FileQueryInfoFlags.NONE);
-                if(type==FileType.DIRECTORY){
+                if (type == FileType.DIRECTORY) {
                     totalFolders++;
-                    //maybe this is an existent already monitored folder
-                    DesktopFolder.FolderManager fm=this.find_folder_by_name(name);
-                    if(fm==null){
-                        //we've found a directory, let's create a desktop-folder window
-                        fm=new DesktopFolder.FolderManager(this, name);
-                    }else{
-                        this.folders.remove(fm);
+                    // maybe this is an existent already monitored folder
+                    DesktopFolder.FolderManager fm = this.find_folder_by_name (name);
+                    if (fm == null) {
+                        // we've found a directory, let's create a desktop-folder window
+                        fm = new DesktopFolder.FolderManager (this, name);
+                    } else {
+                        this.folders.remove (fm);
                     }
-                    updated_folder_list.append(fm);
-                }else{
-                    //maybe a desktop-folder note?
-                    string basename=file.get_basename();
-                    int index=basename.last_index_of(".",0);
-                    if(index>0){
-                        string ext=basename.substring(index+1);
-                        string file_name=basename.substring(0,index);
-                        if(ext==DesktopFolder.NOTE_EXTENSION){
-                            //a note!
+                    updated_folder_list.append (fm);
+                } else {
+                    // maybe a desktop-folder note?
+                    string basename = file.get_basename ();
+                    int    index    = basename.last_index_of (".", 0);
+                    if (index > 0) {
+                        string ext       = basename.substring (index + 1);
+                        string file_name = basename.substring (0, index);
+                        if (ext == DesktopFolder.NOTE_EXTENSION) {
+                            // a note!
                             totalNotes++;
-                            //maybe this is an existent already monitored folder
-                            DesktopFolder.NoteManager nm=this.find_note_by_name(file_name);
-                            if(nm==null){
-                                //debug("new note found!");
-                                //we've found a note file, let's create a note window
-                                nm=new DesktopFolder.NoteManager(this, basename.substring(0,index), file);
-                            }else{
-                                this.notes.remove(nm);
+                            // maybe this is an existent already monitored folder
+                            DesktopFolder.NoteManager nm = this.find_note_by_name (file_name);
+                            if (nm == null) {
+                                // debug("new note found!");
+                                // we've found a note file, let's create a note window
+                                nm = new DesktopFolder.NoteManager (this, basename.substring (0, index), file);
+                            } else {
+                                this.notes.remove (nm);
                             }
-                            updated_note_list.append(nm);
-                        }else if(ext==DesktopFolder.PHOTO_EXTENSION){
-                            //a photo
+                            updated_note_list.append (nm);
+                        } else if (ext == DesktopFolder.PHOTO_EXTENSION)     {
+                            // a photo
                             totalPhotos++;
-                            //maybe this is an existent already monitored photo
-                            DesktopFolder.PhotoManager pm=this.find_photo_by_name(file_name);
-                            if(pm==null){
-                                //debug("new note found!");
-                                //we've found a note file, let's create a note window
-                                pm=new DesktopFolder.PhotoManager(this, basename.substring(0,index), file);
-                            }else{
-                                this.photos.remove(pm);
+                            // maybe this is an existent already monitored photo
+                            DesktopFolder.PhotoManager pm = this.find_photo_by_name (file_name);
+                            if (pm == null) {
+                                // debug("new note found!");
+                                // we've found a note file, let's create a note window
+                                pm = new DesktopFolder.PhotoManager (this, basename.substring (0, index), file);
+                            } else {
+                                this.photos.remove (pm);
                             }
-                            updated_photo_list.append(pm);
+                            updated_photo_list.append (pm);
                         }
                     }
-                    //nothing
-                    //we only deal with folders to be shown
+                    // nothing
+                    // we only deal with folders to be shown
                 }
             }
 
-            //finally we close any other not existent folder
-            while(this.folders.length()>0){
-                DesktopFolder.FolderManager fm=this.folders.nth(0).data;
-                fm.close();
-                this.folders.remove(fm);
+            // finally we close any other not existent folder
+            while (this.folders.length () > 0) {
+                DesktopFolder.FolderManager fm = this.folders.nth (0).data;
+                fm.close ();
+                this.folders.remove (fm);
             }
-            this.folders=updated_folder_list.copy();
+            this.folders = updated_folder_list.copy ();
 
-            //finally we close any other not existent note
-            while(this.notes.length()>0){
-                DesktopFolder.NoteManager nm=this.notes.nth(0).data;
-                nm.close();
-                this.notes.remove(nm);
+            // finally we close any other not existent note
+            while (this.notes.length () > 0) {
+                DesktopFolder.NoteManager nm = this.notes.nth (0).data;
+                nm.close ();
+                this.notes.remove (nm);
             }
-            this.notes=updated_note_list.copy();
+            this.notes = updated_note_list.copy ();
 
-            //finally we close any other not existent photo
-            while(this.photos.length()>0){
-                DesktopFolder.PhotoManager pm=this.photos.nth(0).data;
-                pm.close();
-                this.photos.remove(pm);
+            // finally we close any other not existent photo
+            while (this.photos.length () > 0) {
+                DesktopFolder.PhotoManager pm = this.photos.nth (0).data;
+                pm.close ();
+                this.photos.remove (pm);
             }
-            this.photos=updated_photo_list.copy();
+            this.photos = updated_photo_list.copy ();
 
-            //by default, at least one folder is needed
-            if(totalFolders==0 && totalPhotos==0 && totalNotes==0){
-                DirUtils.create(DesktopFolderApp.get_app_folder()+"/"+DesktopFolder.Lang.APP_FIRST_PANEL,0755);
-                this.sync_folders_and_notes();
+            // by default, at least one folder is needed
+            if (totalFolders == 0 && totalPhotos == 0 && totalNotes == 0) {
+                DirUtils.create (DesktopFolderApp.get_app_folder () + "/" + DesktopFolder.Lang.APP_FIRST_PANEL, 0755);
+                this.sync_folders_and_notes ();
             }
         } catch (Error e) {
-            //error! ??
+            // error! ??
             stderr.printf ("Error: %s\n", e.message);
-            DesktopFolder.Util.show_error_dialog("Error",e.message);
+            DesktopFolder.Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name count_widgets
-    * @description return the amount of widgets existing
-    * @return {int} the total widgets currently shown
-    */
-    public uint count_widgets(){
-        return this.photos.length() + this.notes.length() + this.folders.length();
+     * @name count_widgets
+     * @description return the amount of widgets existing
+     * @return {int} the total widgets currently shown
+     */
+    public uint count_widgets () {
+        return this.photos.length () + this.notes.length () + this.folders.length ();
     }
 
     /**
-    * @name find_folder_by_name
-    * @description find a foldermanager managed by its name
-    * @param string folder_name the name of the folder to find
-    * @return FolderManager the Folder found or null if none
-    */
-    private DesktopFolder.FolderManager? find_folder_by_name(string folder_name){
-        for(int i=0;i<this.folders.length();i++){
-            DesktopFolder.FolderManager fm=this.folders.nth(i).data;
-            if(fm.get_folder_name()==folder_name){
+     * @name find_folder_by_name
+     * @description find a foldermanager managed by its name
+     * @param string folder_name the name of the folder to find
+     * @return FolderManager the Folder found or null if none
+     */
+    private DesktopFolder.FolderManager ? find_folder_by_name (string folder_name) {
+        for (int i = 0 ; i < this.folders.length () ; i++) {
+            DesktopFolder.FolderManager fm = this.folders.nth (i).data;
+            if (fm.get_folder_name () == folder_name) {
                 return fm;
             }
         }
@@ -262,15 +262,15 @@ public class DesktopFolderApp : Gtk.Application {
     }
 
     /**
-    * @name find_note_by_name
-    * @description find a notemanager managed by its name
-    * @param string note_name the name of the note to find
-    * @return NoteManager the Note found or null if none
-    */
-    private DesktopFolder.NoteManager? find_note_by_name(string note_name){
-        for(int i=0;i<this.notes.length();i++){
-            DesktopFolder.NoteManager nm=this.notes.nth(i).data;
-            if(nm.get_note_name()==note_name){
+     * @name find_note_by_name
+     * @description find a notemanager managed by its name
+     * @param string note_name the name of the note to find
+     * @return NoteManager the Note found or null if none
+     */
+    private DesktopFolder.NoteManager ? find_note_by_name (string note_name) {
+        for (int i = 0 ; i < this.notes.length () ; i++) {
+            DesktopFolder.NoteManager nm = this.notes.nth (i).data;
+            if (nm.get_note_name () == note_name) {
                 return nm;
             }
         }
@@ -278,15 +278,15 @@ public class DesktopFolderApp : Gtk.Application {
     }
 
     /**
-    * @name find_photo_by_name
-    * @description find a photomanager managed by its name
-    * @param string photo_name the name of the photo to find
-    * @return PhotoManager the Photo found or null if none
-    */
-    private DesktopFolder.PhotoManager? find_photo_by_name(string photo_name){
-        for(int i=0;i<this.photos.length();i++){
-            DesktopFolder.PhotoManager nm=this.photos.nth(i).data;
-            if(nm.get_photo_name()==photo_name){
+     * @name find_photo_by_name
+     * @description find a photomanager managed by its name
+     * @param string photo_name the name of the photo to find
+     * @return PhotoManager the Photo found or null if none
+     */
+    private DesktopFolder.PhotoManager ? find_photo_by_name (string photo_name) {
+        for (int i = 0 ; i < this.photos.length () ; i++) {
+            DesktopFolder.PhotoManager nm = this.photos.nth (i).data;
+            if (nm.get_photo_name () == photo_name) {
                 return nm;
             }
         }
@@ -294,14 +294,14 @@ public class DesktopFolderApp : Gtk.Application {
     }
 
     /**
-    * @name exist_manager
-    * @description check if the folder_name is being monitored or not
-    * @return bool true->yes, it is being monitored
-    */
-    public bool exist_manager(string folder_name){
-        for(int i=0;i<this.folders.length();i++){
-            DesktopFolder.FolderManager fm=this.folders.nth(i).data;
-            if(fm.get_folder_name()==folder_name){
+     * @name exist_manager
+     * @description check if the folder_name is being monitored or not
+     * @return bool true->yes, it is being monitored
+     */
+    public bool exist_manager (string folder_name) {
+        for (int i = 0 ; i < this.folders.length () ; i++) {
+            DesktopFolder.FolderManager fm = this.folders.nth (i).data;
+            if (fm.get_folder_name () == folder_name) {
                 return true;
             }
         }
@@ -309,126 +309,127 @@ public class DesktopFolderApp : Gtk.Application {
     }
 
     /**
-    * @name monitor_desktop
-    * @description monitor the desktop folder
-    */
-    private void monitor_desktop(){
-        try{
-            if(this.monitor!=null){
-                //if we have an existing monitor, we cancel it before to monitor again
-                this.monitor.cancel();
+     * @name monitor_desktop
+     * @description monitor the desktop folder
+     */
+    private void monitor_desktop () {
+        try {
+            if (this.monitor != null) {
+                // if we have an existing monitor, we cancel it before to monitor again
+                this.monitor.cancel ();
             }
-            var basePath=DesktopFolderApp.get_app_folder();
+            var  basePath  = DesktopFolderApp.get_app_folder ();
             File directory = File.new_for_path (basePath);
-            this.monitor = directory.monitor_directory (FileMonitorFlags.SEND_MOVED,null);
+            this.monitor            = directory.monitor_directory (FileMonitorFlags.SEND_MOVED, null);
             this.monitor.rate_limit = 100;
-            debug("Monitoring: %s\n", directory.get_path ());
-            this.monitor.changed.connect(this.desktop_changed);
+            debug ("Monitoring: %s\n", directory.get_path ());
+            this.monitor.changed.connect (this.desktop_changed);
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            DesktopFolder.Util.show_error_dialog("Error",e.message);
+            DesktopFolder.Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name desktop_changed
-    * @description we received an event of the monitor that indicates a change
-    * @see changed signal of FileMonitor (https://valadoc.org/gio-2.0/GLib.FileMonitor.changed.html)
-    */
-    private void desktop_changed (GLib.File src, GLib.File? dest, FileMonitorEvent event) {
-        //something changed at the desktop folder
-        bool flagNote=false;
-        bool flagPhoto=false;
+     * @name desktop_changed
+     * @description we received an event of the monitor that indicates a change
+     * @see changed signal of FileMonitor (https://valadoc.org/gio-2.0/GLib.FileMonitor.changed.html)
+     */
+    private void desktop_changed (GLib.File src, GLib.File ? dest, FileMonitorEvent event) {
+        // something changed at the desktop folder
+        bool flagNote   = false;
+        bool flagPhoto  = false;
 
-        string basename=src.get_basename();
-        int index=basename.last_index_of(".",0);
-        if(index>0){
-            string ext=basename.substring(index+1);
-            if(ext==DesktopFolder.NOTE_EXTENSION){
-                flagNote=true;
-            }else if(ext==DesktopFolder.PHOTO_EXTENSION){
-                flagPhoto=true;
+        string basename = src.get_basename ();
+        int    index    = basename.last_index_of (".", 0);
+        if (index > 0) {
+            string ext = basename.substring (index + 1);
+            if (ext == DesktopFolder.NOTE_EXTENSION) {
+                flagNote = true;
+            } else if (ext == DesktopFolder.PHOTO_EXTENSION)     {
+                flagPhoto = true;
             }
         }
 
-        //new content inside
-        var file_type= src.query_file_type (FileQueryInfoFlags.NONE);
-        if (flagNote || flagPhoto || file_type==FileType.DIRECTORY || !src.query_exists()){
-            //debug("Desktop - Change Detected");
-            //new directory or removed, we need to synchronize
-            //removed directory
-            this.sync_folders_and_notes();
+        // new content inside
+        var file_type = src.query_file_type (FileQueryInfoFlags.NONE);
+        if (flagNote || flagPhoto || file_type == FileType.DIRECTORY || !src.query_exists ()) {
+            // debug("Desktop - Change Detected");
+            // new directory or removed, we need to synchronize
+            // removed directory
+            this.sync_folders_and_notes ();
         }
     }
 
     /**
-    * @name clear_all
-    * @description close all the folders launched
-    */
-    protected void clear_all(){
-        for(int i=0;i<this.folders.length();i++){
-            DesktopFolder.FolderManager fm=this.folders.nth(i).data;
-            fm.close();
+     * @name clear_all
+     * @description close all the folders launched
+     */
+    protected void clear_all () {
+        for (int i = 0 ; i < this.folders.length () ; i++) {
+            DesktopFolder.FolderManager fm = this.folders.nth (i).data;
+            fm.close ();
         }
-        this.folders=new List<DesktopFolder.FolderManager>();
+        this.folders = new List<DesktopFolder.FolderManager>();
     }
 
     /**
-    * Main application
-    */
+     * Main application
+     */
     public static int main (string[] args) {
-        if(args.length>1 && args[1].up()==DesktopFolder.PARAM_SHOW_DESKTOP.up()){
-            minimize_all(args);
+        if (args.length > 1 && args[1].up () == DesktopFolder.PARAM_SHOW_DESKTOP.up ()) {
+            minimize_all (args);
             return 0;
-        }else{
+        } else {
             var app = new DesktopFolderApp ();
             return app.run (args);
         }
     }
 
     /**
-    * @name minimize_all
-    * @description minimize all windows
-    * @param args string[] the list of args to initialize Gdk
-    */
-    private static void minimize_all(string[] args){
-        Gdk.init(ref args);
-        Wnck.Screen screen = Wnck.Screen.get_default();
-        while(Gtk.events_pending()){
-            Gtk.main_iteration();
+     * @name minimize_all
+     * @description minimize all windows
+     * @param args string[] the list of args to initialize Gdk
+     */
+    private static void minimize_all (string[] args) {
+        Gdk.init (ref args);
+        Wnck.Screen screen = Wnck.Screen.get_default ();
+        while (Gtk.events_pending ()) {
+            Gtk.main_iteration ();
         }
 
-        unowned List<Wnck.Window> windows = screen.get_windows();
+        unowned List<Wnck.Window> windows = screen.get_windows ();
 
-        foreach(Wnck.Window w in windows){
-            Wnck.Application window_app=w.get_application();
-            string name=window_app.get_name();
-            //debug("app name:%s",name);
-            if(name!=DesktopFolder.APP_ID){
-                w.minimize();
+        foreach (Wnck.Window w in windows) {
+            Wnck.Application window_app = w.get_application ();
+            string           name       = window_app.get_name ();
+            // debug("app name:%s",name);
+            if (name != DesktopFolder.APP_ID) {
+                w.minimize ();
             }
         }
     }
 
     /**
-    * @name create_shortchut
-    * @description create a short cut SUPER-D at the system shortcuts to minimize all windows
-    */
-    private static void create_shortchut(){
-        string path="/usr/bin/"; //we expect to have the command at the path
-        Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.init();
-        var shortcut = new Pantheon.Keyboard.Shortcuts.Shortcut (100, Gdk.ModifierType.SUPER_MASK );
-        string command_conflict="";
-        string relocatable_schema_conflict="";
-        if (!Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.shortcut_conflicts(shortcut, out command_conflict,
-             out relocatable_schema_conflict)) {
+     * @name create_shortchut
+     * @description create a short cut SUPER-D at the system shortcuts to minimize all windows
+     */
+    private static void create_shortchut () {
+        string path                        = "/usr/bin/"; // we expect to have the command at the path
+        Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.init ();
+        var    shortcut                    = new Pantheon.Keyboard.Shortcuts.Shortcut (100, Gdk.ModifierType.SUPER_MASK);
+        string command_conflict            = "";
+        string relocatable_schema_conflict = "";
+        if (!Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.shortcut_conflicts (shortcut, out command_conflict,
+                                                                                    out relocatable_schema_conflict)) {
 
-            debug("registering hotkey!");
+            debug ("registering hotkey!");
             var relocatable_schema = Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.create_shortcut ();
             Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.edit_command ((string) relocatable_schema,
-                path + "com.github.spheras.desktopfolder "+ DesktopFolder.PARAM_SHOW_DESKTOP);
+                                                                             path + "com.github.spheras.desktopfolder " + DesktopFolder.PARAM_SHOW_DESKTOP);
             Pantheon.Keyboard.Shortcuts.CustomShortcutSettings.edit_shortcut ((string) relocatable_schema,
-                shortcut.to_gsettings ());
+                                                                              shortcut.to_gsettings ());
         }
     }
+
 }

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -1,135 +1,135 @@
 namespace DesktopFolder.Lang {
-    //Application Description
-    public const string APP_DESCRIPTION=_("Come back to life your minimalist Desktop \n Organize files at your Desktop using Panes.");
-    //Generic Dialog OK Button
-    public const string DIALOG_OK=_("_Ok");
-    //Generic Dialog CANCEL Button
-    public const string DIALOG_CANCEL=_("_Cancel");
-    //Generic Dialog Select Button
-    public const string DIALOG_SELECT=_("_Select");
-    //Trying to paste and the clipboard is empty
-    public const string CLIPBOARD_EMPTY=_("There is nothing on the clipboard to paste");
-    //Dialog Error Title: Invalid Filename provided
-    public const string CANT_DROP=_("Cannot drop this file");
-    //Dialog Error Message while trying to drop
-    public const string CANT_DROP_INVALID_FILE_NAME=_("Invalid file name provided");
-    //Title dialog for File Operations
-    public const string DRAGNDROP_FILE_OPERATIONS=_("File Operations");
-    //Copying File message for progress dialog
-    public const string DRAGNDROP_COPYING=_("Copying");
-    //Drop Menu - Copy
-    public const string DROP_MENU_COPY=_("Copy Here");
-    //Drop Menu - Move
-    public const string DROP_MENU_MOVE=_("Move Here");
-    //Drop Menu - Link
-    public const string DROP_MENU_LINK=_("Link Here");
-    //Drop Menu - Cancel
-    public const string DROP_MENU_CANCEL=_("Cancel");
-    //desktopfolder menu - create a new Desktop-Folder Pane
-    public const string DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER=_("Panel");
-    //desktopfolder menu - enable/disable alignment to grid
-    public const string DESKTOPFOLDER_MENU_ALIGN_TO_GRID=_("Align to Grid");
-    //desktopfolder menu - enable/disable text shadows
-    public const string DESKTOPFOLDER_MENU_TEXT_SHADOW=_("Text Shadow");
-    //desktopfolder menu - enable/disable text bolds
-    public const string DESKTOPFOLDER_MENU_TEXT_BOLD=_("Text Bold");
-    //desktopfolder menu - create a new Note
-    public const string DESKTOPFOLDER_MENU_NEW_NOTE=_("Note");
-    //desktopfolder menu - create a new Folder
-    public const string DESKTOPFOLDER_MENU_NEW_FOLDER=_("Folder");
-    //desktopfolder menu - create a new empty Text File
-    public const string DESKTOPFOLDER_MENU_NEW_EMPTY_FILE=_("Empty File");
-    //desktopfolder menu - rename a Desktop-Folder Pane
-    public const string DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER=_("Rename Panel");
-    //desktopfolder menu - remove a Desktop-Folder Pane
-    public const string DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER=_("Move Panel to Trash");
-    //desktopfolder menu - past from clipboard to the desktop-folder
-    public const string DESKTOPFOLDER_MENU_PASTE=_("Paste");
-    //desktopfolder - Dialog Title for a new Desktop Folder Panel to ask the new name
-    public const string DESKTOPFOLDER_NEW=_("New Panel");
-    //desktopfolder - Dialog Message to rename the current Desktop-Folder
-    public const string DESKTOPFOLDER_RENAME_MESSAGE=_("Enter the new name");
-    //desktopfolder - Title for a Dialog Text to ask the new name for the Desktop-Folder
-    public const string DESKTOPFOLDER_ENTER_TITLE=_("New Panel");
-    //desktopfolder - Dialog Text to ask the new name for the Desktop-Folder
-    public const string DESKTOPFOLDER_ENTER_NAME=_("Enter the name");
-    //desktopfolder - Title for Dialog to ask the new name for a folder inside a Desktop-Folder
-    public const string DESKTOPFOLDER_NEW_FOLDER_TITLE=_("New Folder");
-    //desktopfolder - Dialog Text to ask the new name for a folder inside a Desktop-Folder
-    public const string DESKTOPFOLDER_NEW_FOLDER_MESSAGE=_("Enter the name");
-    //desktopfolder - The default name for the new folder to be created
-    public const string DESKTOPFOLDER_NEW_FOLDER_NAME=_("new folder");
-    //desktopfolder - Dialog Title to ask the new name for a text file inside a Desktop-Folder
-    public const string DESKTOPFOLDER_NEW_TEXT_FILE_TITLE=_("New Text File");
-    //desktopfolder - Dialog Text to ask the new name for a text file inside a Desktop-Folder
-    public const string DESKTOPFOLDER_NEW_TEXT_FILE_MESSAGE=_("Enter the name");
-    //desktopfolder - The default name for the new text file to be created
-    public const string DESKTOPFOLDER_NEW_TEXT_FILE_NAME=_("new.txt");
-    //desktopfolder - The message to confirm the deletion of a Desktop Folder
-    public const string DESKTOPFOLDER_DELETE_MESSAGE=_("This action will DELETE the DESKTOP-FOLDER and ALL the files inside.\n<b>Are you sure?</b>");
-    //desktopfolder - Title for a Dialog Text to ask the new name for the Desktop-Folder
-    public const string NOTE_ENTER_TITLE=_("New Note");
-    //desktopfolder - Dialog Text to ask the new name for the Desktop-Folder
-    public const string NOTE_ENTER_NAME=_("Enter the name");
-    //desktopfolder - Dialog Title for a new Desktop Folder Panel to ask the new name
-    public const string NOTE_NEW=_("New Note");
-    //Note - popup option to set the paper texture or not
-    public const string NOTE_MENU_PAPER_NOTE=_("Paper Texture");
-    //Menu popup option to rename the note
-    public const string NOTE_MENU_RENAME_NOTE=_("Rename Note");
-    //Menu popup option to delete the note
-    public const string NOTE_MENU_DELETE_NOTE=_("Move to Trash");
-    //Note - Dialog Title Message to rename the current note
-    public const string NOTE_RENAME_TITLE=_("Rename Note");
-    //Note - Dialog Message to rename the current note
-    public const string NOTE_RENAME_MESSAGE=_("Enter the new name");
-    //Note - Dialog Message to DELETE the current note
-    public const string NOTE_DELETE_MESSAGE=_("This action will DELETE the Note.\n<b>Are you sure?</b>");
+    // Application Description
+    public const string APP_DESCRIPTION                          = _("Come back to life your minimalist Desktop \n Organize files at your Desktop using Panes.");
+    // Generic Dialog OK Button
+    public const string DIALOG_OK                                = _("_Ok");
+    // Generic Dialog CANCEL Button
+    public const string DIALOG_CANCEL                            = _("_Cancel");
+    // Generic Dialog Select Button
+    public const string DIALOG_SELECT                            = _("_Select");
+    // Trying to paste and the clipboard is empty
+    public const string CLIPBOARD_EMPTY                          = _("There is nothing on the clipboard to paste");
+    // Dialog Error Title: Invalid Filename provided
+    public const string CANT_DROP                                = _("Cannot drop this file");
+    // Dialog Error Message while trying to drop
+    public const string CANT_DROP_INVALID_FILE_NAME              = _("Invalid file name provided");
+    // Title dialog for File Operations
+    public const string DRAGNDROP_FILE_OPERATIONS                = _("File Operations");
+    // Copying File message for progress dialog
+    public const string DRAGNDROP_COPYING                        = _("Copying");
+    // Drop Menu - Copy
+    public const string DROP_MENU_COPY                           = _("Copy Here");
+    // Drop Menu - Move
+    public const string DROP_MENU_MOVE                           = _("Move Here");
+    // Drop Menu - Link
+    public const string DROP_MENU_LINK                           = _("Link Here");
+    // Drop Menu - Cancel
+    public const string DROP_MENU_CANCEL                         = _("Cancel");
+    // desktopfolder menu - create a new Desktop-Folder Pane
+    public const string DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER    = _("Panel");
+    // desktopfolder menu - enable/disable alignment to grid
+    public const string DESKTOPFOLDER_MENU_ALIGN_TO_GRID         = _("Align to Grid");
+    // desktopfolder menu - enable/disable text shadows
+    public const string DESKTOPFOLDER_MENU_TEXT_SHADOW           = _("Text Shadow");
+    // desktopfolder menu - enable/disable text bolds
+    public const string DESKTOPFOLDER_MENU_TEXT_BOLD             = _("Text Bold");
+    // desktopfolder menu - create a new Note
+    public const string DESKTOPFOLDER_MENU_NEW_NOTE              = _("Note");
+    // desktopfolder menu - create a new Folder
+    public const string DESKTOPFOLDER_MENU_NEW_FOLDER            = _("Folder");
+    // desktopfolder menu - create a new empty Text File
+    public const string DESKTOPFOLDER_MENU_NEW_EMPTY_FILE        = _("Empty File");
+    // desktopfolder menu - rename a Desktop-Folder Pane
+    public const string DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER = _("Rename Panel");
+    // desktopfolder menu - remove a Desktop-Folder Pane
+    public const string DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER = _("Move Panel to Trash");
+    // desktopfolder menu - past from clipboard to the desktop-folder
+    public const string DESKTOPFOLDER_MENU_PASTE                 = _("Paste");
+    // desktopfolder - Dialog Title for a new Desktop Folder Panel to ask the new name
+    public const string DESKTOPFOLDER_NEW                        = _("New Panel");
+    // desktopfolder - Dialog Message to rename the current Desktop-Folder
+    public const string DESKTOPFOLDER_RENAME_MESSAGE             = _("Enter the new name");
+    // desktopfolder - Title for a Dialog Text to ask the new name for the Desktop-Folder
+    public const string DESKTOPFOLDER_ENTER_TITLE                = _("New Panel");
+    // desktopfolder - Dialog Text to ask the new name for the Desktop-Folder
+    public const string DESKTOPFOLDER_ENTER_NAME                 = _("Enter the name");
+    // desktopfolder - Title for Dialog to ask the new name for a folder inside a Desktop-Folder
+    public const string DESKTOPFOLDER_NEW_FOLDER_TITLE           = _("New Folder");
+    // desktopfolder - Dialog Text to ask the new name for a folder inside a Desktop-Folder
+    public const string DESKTOPFOLDER_NEW_FOLDER_MESSAGE         = _("Enter the name");
+    // desktopfolder - The default name for the new folder to be created
+    public const string DESKTOPFOLDER_NEW_FOLDER_NAME            = _("new folder");
+    // desktopfolder - Dialog Title to ask the new name for a text file inside a Desktop-Folder
+    public const string DESKTOPFOLDER_NEW_TEXT_FILE_TITLE        = _("New Text File");
+    // desktopfolder - Dialog Text to ask the new name for a text file inside a Desktop-Folder
+    public const string DESKTOPFOLDER_NEW_TEXT_FILE_MESSAGE      = _("Enter the name");
+    // desktopfolder - The default name for the new text file to be created
+    public const string DESKTOPFOLDER_NEW_TEXT_FILE_NAME         = _("new.txt");
+    // desktopfolder - The message to confirm the deletion of a Desktop Folder
+    public const string DESKTOPFOLDER_DELETE_MESSAGE             = _("This action will DELETE the DESKTOP-FOLDER and ALL the files inside.\n<b>Are you sure?</b>");
+    // desktopfolder - Title for a Dialog Text to ask the new name for the Desktop-Folder
+    public const string NOTE_ENTER_TITLE                         = _("New Note");
+    // desktopfolder - Dialog Text to ask the new name for the Desktop-Folder
+    public const string NOTE_ENTER_NAME                          = _("Enter the name");
+    // desktopfolder - Dialog Title for a new Desktop Folder Panel to ask the new name
+    public const string NOTE_NEW              = _("New Note");
+    // Note - popup option to set the paper texture or not
+    public const string NOTE_MENU_PAPER_NOTE  = _("Paper Texture");
+    // Menu popup option to rename the note
+    public const string NOTE_MENU_RENAME_NOTE = _("Rename Note");
+    // Menu popup option to delete the note
+    public const string NOTE_MENU_DELETE_NOTE = _("Move to Trash");
+    // Note - Dialog Title Message to rename the current note
+    public const string NOTE_RENAME_TITLE     = _("Rename Note");
+    // Note - Dialog Message to rename the current note
+    public const string NOTE_RENAME_MESSAGE   = _("Enter the new name");
+    // Note - Dialog Message to DELETE the current note
+    public const string NOTE_DELETE_MESSAGE   = _("This action will DELETE the Note.\n<b>Are you sure?</b>");
 
-    //Item Menu - Open the file
-    public const string ITEM_MENU_OPEN=_("Open");
-    //Item Menu - Execute the file
-    public const string ITEM_MENU_EXECUTE=_("Execute");
-    //Item Menu - cut the file/folder
-    public const string ITEM_MENU_CUT=_("Cut");
-    //Item Menu - copy the file/folder
-    public const string ITEM_MENU_COPY=_("Copy");
-    //Item Menu - rename the file/folder
-    public const string ITEM_MENU_RENAME=_("Rename");
-    //Item Menu - delete the file/folder
-    public const string ITEM_MENU_DELETE=_("Delete");
-    //Item Menu - change icon
-    public const string ITEM_MENU_CHANGEICON=_("Change Icon");
-    //Item - Delete Folder Item Dialog message
-    public const string ITEM_DELETE_FOLDER_MESSAGE=_("This action will DELETE the folder and ALL its content.\n<b>Are you sure?</b>");
-    //Item - Delete File Item Dialog message
-    public const string ITEM_DELETE_FILE_MESSAGE=_("This action will DELETE the file.\n<b>Are you sure?</b>");
-    //Item - Delete File Link Dialog message
-    public const string ITEM_DELETE_LINK_MESSAGE=_("This action will DELETE the link (just the link).\n<b>Are you sure?</b>");
-    //Item - Change icon dialog message to select an image file
-    public const string ITEM_CHANGEICON_MESSAGE=_("Select the image icon to be used.");
-    //Item - Rename Dialog Title
-    public const string ITEM_RENAME_TITLE=_("Rename Item");
-    //Item - Rename Dialog Message
-    public const string ITEM_RENAME_MESSAGE=_("Enter the new name");
-    //Name of the first desktop-folder panel, when no panels found
-    public const string APP_FIRST_PANEL=_("My First Panel");
-    //Hint to show desktop shortcut
-    //public const string HINT_SHOW_DESKTOP=_("Press ⌘-D to Show Desktop");
-    //Menu option to create a link to a file
-    public const string DESKTOPFOLDER_MENU_NEW_FILE_LINK=_("Link to File");
-    //Menu option to create a link to a folder
-    public const string DESKTOPFOLDER_MENU_NEW_FOLDER_LINK=_("Link to Folder");
-    //Dialog message to create a new link
-    public const string DESKTOPFOLDER_LINK_MESSAGE=_("Select the destination file/folder of the link");
-    //Menu popup option to remove a photo
-    public const string PHOTO_MENU_DELETE_PHOTO=_("Remove");
-    //Note - Dialog Message to DELETE the current photo
-    public const string PHOTO_DELETE_MESSAGE=_("This action will DELETE the Photo.\n<b>Are you sure?</b>");
-    //desktopfolder menu - create a new Photo
-    public const string DESKTOPFOLDER_MENU_NEW_PHOTO=_("Photo");
-    //dialog message to select an image file to be shown at the desktop
-    public const string PHOTO_SELECT_PHOTO_MESSAGE=_("Select the picture to show");
-    //desktopfolder menu - create a new empty Text File
-    public const string DESKTOPFOLDER_MENU_NEW_SUBMENU=_("New");
+    // Item Menu - Open the file
+    public const string ITEM_MENU_OPEN             = _("Open");
+    // Item Menu - Execute the file
+    public const string ITEM_MENU_EXECUTE          = _("Execute");
+    // Item Menu - cut the file/folder
+    public const string ITEM_MENU_CUT              = _("Cut");
+    // Item Menu - copy the file/folder
+    public const string ITEM_MENU_COPY             = _("Copy");
+    // Item Menu - rename the file/folder
+    public const string ITEM_MENU_RENAME           = _("Rename");
+    // Item Menu - delete the file/folder
+    public const string ITEM_MENU_DELETE           = _("Delete");
+    // Item Menu - change icon
+    public const string ITEM_MENU_CHANGEICON       = _("Change Icon");
+    // Item - Delete Folder Item Dialog message
+    public const string ITEM_DELETE_FOLDER_MESSAGE = _("This action will DELETE the folder and ALL its content.\n<b>Are you sure?</b>");
+    // Item - Delete File Item Dialog message
+    public const string ITEM_DELETE_FILE_MESSAGE   = _("This action will DELETE the file.\n<b>Are you sure?</b>");
+    // Item - Delete File Link Dialog message
+    public const string ITEM_DELETE_LINK_MESSAGE   = _("This action will DELETE the link (just the link).\n<b>Are you sure?</b>");
+    // Item - Change icon dialog message to select an image file
+    public const string ITEM_CHANGEICON_MESSAGE    = _("Select the image icon to be used.");
+    // Item - Rename Dialog Title
+    public const string ITEM_RENAME_TITLE          = _("Rename Item");
+    // Item - Rename Dialog Message
+    public const string ITEM_RENAME_MESSAGE        = _("Enter the new name");
+    // Name of the first desktop-folder panel, when no panels found
+    public const string APP_FIRST_PANEL            = _("My First Panel");
+    // Hint to show desktop shortcut
+    // public const string HINT_SHOW_DESKTOP=_("Press ⌘-D to Show Desktop");
+    // Menu option to create a link to a file
+    public const string DESKTOPFOLDER_MENU_NEW_FILE_LINK   = _("Link to File");
+    // Menu option to create a link to a folder
+    public const string DESKTOPFOLDER_MENU_NEW_FOLDER_LINK = _("Link to Folder");
+    // Dialog message to create a new link
+    public const string DESKTOPFOLDER_LINK_MESSAGE         = _("Select the destination file/folder of the link");
+    // Menu popup option to remove a photo
+    public const string PHOTO_MENU_DELETE_PHOTO            = _("Remove");
+    // Note - Dialog Message to DELETE the current photo
+    public const string PHOTO_DELETE_MESSAGE               = _("This action will DELETE the Photo.\n<b>Are you sure?</b>");
+    // desktopfolder menu - create a new Photo
+    public const string DESKTOPFOLDER_MENU_NEW_PHOTO       = _("Photo");
+    // dialog message to select an image file to be shown at the desktop
+    public const string PHOTO_SELECT_PHOTO_MESSAGE         = _("Select the picture to show");
+    // desktopfolder menu - create a new empty Text File
+    public const string DESKTOPFOLDER_MENU_NEW_SUBMENU     = _("New");
 }

--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -10,20 +10,20 @@
     You should have received a copy of the GNU General Public License along
     with this program. If not, see <http://www.gnu.org/licenses/>.
     Authors :
-***/
+ ***/
 
 namespace DesktopFolder {
-    public const string APP_ID = "com.github.spheras.desktopfolder";
-    public const string APP_DESKTOP = APP_ID + ".desktop";
-    public const string APP_TITLE = "Desktop-Folder";
-    public const string APP_NAME = "desktopfolder";
-    public const string VERSION = "1.0.2";
+    public const string APP_ID               = "com.github.spheras.desktopfolder";
+    public const string APP_DESKTOP          = APP_ID + ".desktop";
+    public const string APP_TITLE            = "Desktop-Folder";
+    public const string APP_NAME             = "desktopfolder";
+    public const string VERSION              = "1.0.2";
     /** Name of the Folder Settings File */
-    public const string FOLDER_SETTINGS_FILE=".desktopfolder";
-    public const string NOTE_EXTENSION="dfn";
-    public const string PHOTO_EXTENSION="dfp";
+    public const string FOLDER_SETTINGS_FILE = ".desktopfolder";
+    public const string NOTE_EXTENSION       = "dfn";
+    public const string PHOTO_EXTENSION      = "dfp";
     /** param to show the desktop */
-    public const string PARAM_SHOW_DESKTOP="show-desktop";
-    public const int ICON_SIZE=48;
+    public const string PARAM_SHOW_DESKTOP   = "show-desktop";
+    public const int    ICON_SIZE            = 48;
 
 }

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -1,558 +1,555 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Desktop Folder Manager
-*/
-public class DesktopFolder.FolderManager: Object, DragnDrop.DndView {
+ * @class
+ * Desktop Folder Manager
+ */
+public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
     /** parent application */
     private DesktopFolderApp application;
     /** the view of this logic */
-    private FolderWindow view=null;
+    private FolderWindow view                    = null;
     /** Folder Settings of this folder */
-    private FolderSettings settings=null;
+    private FolderSettings settings              = null;
     /** File Monitor of this folder */
-    private FileMonitor monitor=null;
+    private FileMonitor monitor                  = null;
     /** List of items of this folder */
-    private List<ItemManager> items=null;
+    private List<ItemManager> items              = null;
     /** name of the folder */
-    private string folder_name=null;
+    private string folder_name                   = null;
     /** drag and drop behaviour for this folder */
-    private DragnDrop.DndBehaviour dnd_behaviour=null;
+    private DragnDrop.DndBehaviour dnd_behaviour = null;
 
     /**
-    * @constructor
-    * @param DesktopFolderApp application the application owner of this window
-    * @param string folder_name the name of the folder
-    */
-    public FolderManager(DesktopFolderApp application, string folder_name){
-        this.folder_name=folder_name;
+     * @constructor
+     * @param DesktopFolderApp application the application owner of this window
+     * @param string folder_name the name of the folder
+     */
+    public FolderManager (DesktopFolderApp application, string folder_name) {
+        this.folder_name = folder_name;
 
-        //Let's load the settings of the folder (if exist or a new one)
-        this.load_folder_settings();
+        // Let's load the settings of the folder (if exist or a new one)
+        this.load_folder_settings ();
 
-        //First we create a Folder Window above the desktop
-        this.application=application;
-        this.view = new DesktopFolder.FolderWindow (this);
-        this.application.add_window(this.view);
+        // First we create a Folder Window above the desktop
+        this.application = application;
+        this.view        = new DesktopFolder.FolderWindow (this);
+        this.application.add_window (this.view);
         this.view.show ();
 
-        //trying to put it in front of the rest
-        this.view.set_keep_below(false);
-        this.view.set_keep_above(true);
-        this.view.present();
-        this.view.set_keep_above(false);
-        this.view.set_keep_below(true);
-        //---------------------------------------
+        // trying to put it in front of the rest
+        this.view.set_keep_below (false);
+        this.view.set_keep_above (true);
+        this.view.present ();
+        this.view.set_keep_above (false);
+        this.view.set_keep_below (true);
+        // ---------------------------------------
 
-        //let's sync the files found at this folder
-        this.sync_files(0,0);
+        // let's sync the files found at this folder
+        this.sync_files (0, 0);
 
-        //finally, we start monitoring the folder
-        this.monitor_folder();
+        // finally, we start monitoring the folder
+        this.monitor_folder ();
 
-        this.dnd_behaviour=new DragnDrop.DndBehaviour(this, false, true);
+        this.dnd_behaviour = new DragnDrop.DndBehaviour (this, false, true);
     }
 
     /**
-    * @name load_folder_settings
-    * @description load the settings file inside the folder (if exist), if not, it will create a new one.
-    * The settings file contains the basic info saved to create window and items componentes.. position, size, etc..
-    */
-    private void load_folder_settings(){
-        //let's search the folder settings file
-        var abs_path=this.get_absolute_path();
-        debug("loading folder settings...%s",abs_path);
-        var settings_file=abs_path+"/.desktopfolder";
-        var file = File.new_for_path (settings_file);
+     * @name load_folder_settings
+     * @description load the settings file inside the folder (if exist), if not, it will create a new one.
+     * The settings file contains the basic info saved to create window and items componentes.. position, size, etc..
+     */
+    private void load_folder_settings () {
+        // let's search the folder settings file
+        var abs_path      = this.get_absolute_path ();
+        debug ("loading folder settings...%s", abs_path);
+        var settings_file = abs_path + "/.desktopfolder";
+        var file          = File.new_for_path (settings_file);
         if (!file.query_exists ()) {
-            //we don't have yet a folder settings file, let's create one
-            FolderSettings newone=new FolderSettings(this.folder_name);
-            newone.save_to_file(file);
-            this.settings=newone;
-        }else{
-            FolderSettings existent=FolderSettings.read_settings(file, this.get_folder_name());
-            this.settings=existent;
+            // we don't have yet a folder settings file, let's create one
+            FolderSettings newone = new FolderSettings (this.folder_name);
+            newone.save_to_file (file);
+            this.settings = newone;
+        } else {
+            FolderSettings existent = FolderSettings.read_settings (file, this.get_folder_name ());
+            this.settings = existent;
         }
     }
 
     /**
-    * @name monitor_folder
-    * @description monitor the folder owned by this manager looking for changes inside
-    */
-    private void monitor_folder(){
-        try{
-            if(this.monitor!=null){
-                //if we have an existing monitor, we cancel it before to monitor again
-                this.monitor.cancel();
+     * @name monitor_folder
+     * @description monitor the folder owned by this manager looking for changes inside
+     */
+    private void monitor_folder () {
+        try {
+            if (this.monitor != null) {
+                // if we have an existing monitor, we cancel it before to monitor again
+                this.monitor.cancel ();
             }
-            File directory = this.get_file();
-            this.monitor = directory.monitor_directory (FileMonitorFlags.SEND_MOVED,null);
+            File directory = this.get_file ();
+            this.monitor            = directory.monitor_directory (FileMonitorFlags.SEND_MOVED, null);
             this.monitor.rate_limit = 100;
-            debug("Monitoring: %s", directory.get_path ());
-            this.monitor.changed.connect(this.directory_changed);
+            debug ("Monitoring: %s", directory.get_path ());
+            this.monitor.changed.connect (this.directory_changed);
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name directory_changed
-    * @description we received an event of the monitor that indicates a change
-    * @see changed signal of FileMonitor (https://valadoc.org/gio-2.0/GLib.FileMonitor.changed.html)
-    */
-    private void directory_changed (GLib.File src, GLib.File? dest, FileMonitorEvent event) {
-        File file_myself=this.get_file();
-        if(file_myself.get_path()==src.get_path()){
-            //its me! maybe I was removed :(
+     * @name directory_changed
+     * @description we received an event of the monitor that indicates a change
+     * @see changed signal of FileMonitor (https://valadoc.org/gio-2.0/GLib.FileMonitor.changed.html)
+     */
+    private void directory_changed (GLib.File src, GLib.File ? dest, FileMonitorEvent event) {
+        File file_myself = this.get_file ();
+        if (file_myself.get_path () == src.get_path ()) {
+            // its me! maybe I was removed :(
             return;
         }
-        string old_filename=src.get_basename ();
-        if(old_filename==DesktopFolder.FOLDER_SETTINGS_FILE){
-            //we ignore the settings file changes
-        }else{
-            debug("%s - Change Detected",this.get_folder_name());
-            if(dest!=null && src.query_exists() && dest.query_exists()){
-                //something has been renamed
-                string new_filename=dest.get_basename ();
-                this.settings.rename(old_filename,new_filename);
-                this.settings.save();
+        string old_filename = src.get_basename ();
+        if (old_filename == DesktopFolder.FOLDER_SETTINGS_FILE) {
+            // we ignore the settings file changes
+        } else {
+            debug ("%s - Change Detected", this.get_folder_name ());
+            if (dest != null && src.query_exists () && dest.query_exists ()) {
+                // something has been renamed
+                string new_filename = dest.get_basename ();
+                this.settings.rename (old_filename, new_filename);
+                this.settings.save ();
 
-                //we need to rename the affected file/folder
-                for(int i=0;i<this.items.length();i++){
-                    ItemManager element=(ItemManager) this.items.nth_data(i);
-                    if(element.get_file_name()==old_filename){
-                        element.rename(new_filename);
+                // we need to rename the affected file/folder
+                for (int i = 0 ; i < this.items.length () ; i++) {
+                    ItemManager element = (ItemManager) this.items.nth_data (i);
+                    if (element.get_file_name () == old_filename) {
+                        element.rename (new_filename);
                     }
                 }
 
-                //finally we refresh the view
-                this.view.refresh();
-            }else {
-                //somehthing changed.. created or removed
-                this.sync_files(0,0);
+                // finally we refresh the view
+                this.view.refresh ();
+            } else {
+                // somehthing changed.. created or removed
+                this.sync_files (0, 0);
             }
 
         }
     }
 
     /**
-    * @name get_folder_name
-    * @description return the folder name
-    * @return string the folder name
-    */
-    public string get_folder_name(){
+     * @name get_folder_name
+     * @description return the folder name
+     * @return string the folder name
+     */
+    public string get_folder_name () {
         return this.folder_name;
     }
 
     /**
-    * @name get_application
-    * @description return the desktop folder application
-    * @return DesktopFolderApp
-    */
-    public DesktopFolderApp get_application(){
+     * @name get_application
+     * @description return the desktop folder application
+     * @return DesktopFolderApp
+     */
+    public DesktopFolderApp get_application () {
         return this.application;
     }
 
     /**
-    * @name sync_files
-    * @description sync all the files contained at the folder this manager refers to
-    * @param x int the x position where any new item found should be positioned, <=0 if this algorithm must decide
-    * @param y int the y position where any new item found should be positioned, <=0 if this algorithm must decide
-    */
-    public void sync_files(int x, int y){
-        debug("syncingfiles for folder %s, %d, %d",this.get_folder_name(), x, y);
+     * @name sync_files
+     * @description sync all the files contained at the folder this manager refers to
+     * @param x int the x position where any new item found should be positioned, <=0 if this algorithm must decide
+     * @param y int the y position where any new item found should be positioned, <=0 if this algorithm must decide
+     */
+    public void sync_files (int x, int y) {
+        debug ("syncingfiles for folder %s, %d, %d", this.get_folder_name (), x, y);
         try {
-            this.load_folder_settings();
-            this.clear_all();
-            string base_path=this.get_absolute_path();
-            File directory=this.get_file();
+            this.load_folder_settings ();
+            this.clear_all ();
+            string base_path = this.get_absolute_path ();
+            File   directory = this.get_file ();
 
-            //listing all the files inside this folder
-            var enumerator = directory.enumerate_children (FileAttribute.STANDARD_NAME, 0);
+            // listing all the files inside this folder
+            var      enumerator = directory.enumerate_children (FileAttribute.STANDARD_NAME, 0);
             FileInfo file_info;
             while ((file_info = enumerator.next_file ()) != null) {
-                string file_name=file_info.get_name();
-                //debug("found:%s", file_name);
-                File file = File.new_for_commandline_arg (base_path + "/" + file_name);
+                string file_name = file_info.get_name ();
+                // debug("found:%s", file_name);
+                File file        = File.new_for_commandline_arg (base_path + "/" + file_name);
 
-                    if(file_name.index_of(".",0)!=0){
-                        //debug("creating an item...");
+                if (file_name.index_of (".", 0) != 0) {
+                    // debug("creating an item...");
 
-                        //we try to get the settings for this item
-                        ItemSettings is=this.settings.get_item(file_name);
-                        if(is==null){
-                            //we need to create one empty
-                            is=new ItemSettings();
-                            is.x=x;
-                            is.y=y;
-                            is.name=file_name;
-                            this.settings.add_item(is);
-                        }
-
-                        ItemManager item=new ItemManager(file_name, file, this);
-                        this.items.append(item);
-
-                        this.view.add_item(item.get_view(),is.x,is.y);
-                    }else{
-                        //debug("missing hidden files: %s",fileName);
-                        //we don't consider hidden files
+                    // we try to get the settings for this item
+                    ItemSettings is = this.settings.get_item (file_name);
+                    if (is == null) {
+                        // we need to create one empty
+                        is      = new ItemSettings ();
+                        is.x    = x;
+                        is.y    = y;
+                        is.name = file_name;
+                        this.settings.add_item (is);
                     }
+
+                    ItemManager item = new ItemManager (file_name, file, this);
+                    this.items.append (item);
+
+                    this.view.add_item (item.get_view (), is.x, is.y);
+                } else {
+                    // debug("missing hidden files: %s",fileName);
+                    // we don't consider hidden files
+                }
             }
-            this.settings.save();
-            this.view.refresh();
+            this.settings.save ();
+            this.view.refresh ();
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name clear_all
-    * @description clear all the items associated with this folder
-    */
-    public void clear_all(){
-        this.items=new List<ItemManager>();
-        this.view.clear_all();
+     * @name clear_all
+     * @description clear all the items associated with this folder
+     */
+    public void clear_all () {
+        this.items = new List<ItemManager>();
+        this.view.clear_all ();
     }
 
     /**
-    * @name create_new_folder
-    * @description create a new folder inside this folder
-    * @param string name the name of the new folder
-    * @param int x the x position of the new folder
-    * @param int y the y position of the new folder
-    */
-    public void create_new_folder(string name, int x, int y){
-        //cancelling the current monitor
-        this.monitor.cancel();
-        DirUtils.create(this.get_absolute_path()+"/"+name,0755);
-        //forcing the sync of the files as a new folder has been created
-        this.sync_files(x,y);
-        //monitoring again
-        this.monitor_folder();
+     * @name create_new_folder
+     * @description create a new folder inside this folder
+     * @param string name the name of the new folder
+     * @param int x the x position of the new folder
+     * @param int y the y position of the new folder
+     */
+    public void create_new_folder (string name, int x, int y) {
+        // cancelling the current monitor
+        this.monitor.cancel ();
+        DirUtils.create (this.get_absolute_path () + "/" + name, 0755);
+        // forcing the sync of the files as a new folder has been created
+        this.sync_files (x, y);
+        // monitoring again
+        this.monitor_folder ();
     }
 
-
     /**
-    * @name create_new_text_file
-    * @description create a new text file inside this folder
-    * @param string name the name of the new text file
-    * @param int x the x position of the new file
-    * @param int y the y position of the new file
-    */
-    public void create_new_text_file(string name, int x, int y){
-        //cancelling the current monitor
-        this.monitor.cancel();
+     * @name create_new_text_file
+     * @description create a new text file inside this folder
+     * @param string name the name of the new text file
+     * @param int x the x position of the new file
+     * @param int y the y position of the new file
+     */
+    public void create_new_text_file (string name, int x, int y) {
+        // cancelling the current monitor
+        this.monitor.cancel ();
 
-        //we create the text file with a touch command
+        // we create the text file with a touch command
         try {
-            var command="touch \""+this.get_absolute_path()+"/"+name+"\"";
+            var command = "touch \"" + this.get_absolute_path () + "/" + name + "\"";
             var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.SUPPORTS_URIS);
             appinfo.launch_uris (null, null);
 
-            //forcing the sync of the files as a new folder has been created
-            this.sync_files(x,y);
-            //monitoring again
-            this.monitor_folder();
+            // forcing the sync of the files as a new folder has been created
+            this.sync_files (x, y);
+            // monitoring again
+            this.monitor_folder ();
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name create_new_link
-    * @description create a new link inside this folder
-    * @param string target the target of the new link file
-    * @param int x the x position of the new file
-    * @param int y the y position of the new file
-    */
-    public void create_new_link(string target, int x, int y){
-        //cancelling the current monitor
-        this.monitor.cancel();
+     * @name create_new_link
+     * @description create a new link inside this folder
+     * @param string target the target of the new link file
+     * @param int x the x position of the new file
+     * @param int y the y position of the new file
+     */
+    public void create_new_link (string target, int x, int y) {
+        // cancelling the current monitor
+        this.monitor.cancel ();
 
-        //we create the text file with a touch command
+        // we create the text file with a touch command
         try {
-            var file = File.new_for_path (target);
-            var name=file.get_basename();
-            var command="ln -s \""+target+"\" \""+ this.get_absolute_path()+"/"+name+"\"";
-            //debug("command: %s"+command);
+            var file    = File.new_for_path (target);
+            var name    = file.get_basename ();
+            var command = "ln -s \"" + target + "\" \"" + this.get_absolute_path () + "/" + name + "\"";
+            // debug("command: %s"+command);
             var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.SUPPORTS_URIS);
             appinfo.launch_uris (null, null);
 
-            //forcing the sync of the files as a new lynk has been created
-            this.sync_files(x,y);
-            //monitoring again
-            this.monitor_folder();
+            // forcing the sync of the files as a new lynk has been created
+            this.sync_files (x, y);
+            // monitoring again
+            this.monitor_folder ();
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name delete
-    * @description deleting myself!!
-    */
-    public void delete(){
-        //lets delete
-        try{
-            if(this.application.count_widgets()>1){
-                File file=File.new_for_path (this.get_absolute_path());
-                file.trash();
-                this.close();
-            }else{
-                for(int i=0;i<this.items.length();i++){
-                    this.items.nth_data(i).delete();
+     * @name delete
+     * @description deleting myself!!
+     */
+    public void delete () {
+        // lets delete
+        try {
+            if (this.application.count_widgets () > 1) {
+                File file = File.new_for_path (this.get_absolute_path ());
+                file.trash ();
+                this.close ();
+            } else {
+                for (int i = 0 ; i < this.items.length () ; i++) {
+                    this.items.nth_data (i).delete ();
                 }
 
-                this.clear_all();
-                this.settings.reset();
-                this.settings.save();
-                this.rename(DesktopFolder.Lang.APP_FIRST_PANEL);
-                this.view.reload_settings();
-                this.view.queue_draw();
-                this.view.show_all();
+                this.clear_all ();
+                this.settings.reset ();
+                this.settings.save ();
+                this.rename (DesktopFolder.Lang.APP_FIRST_PANEL);
+                this.view.reload_settings ();
+                this.view.queue_draw ();
+                this.view.show_all ();
             }
-        }catch(Error error){
+        } catch (Error error) {
             stderr.printf ("Error: %s\n", error.message);
-            Util.show_error_dialog("Error",error.message);
+            Util.show_error_dialog ("Error", error.message);
         }
     }
 
     /**
-    * @name close
-    * @description close the folder manager and its view
-    */
-    public void close(){
-        this.monitor.cancel();
-        this.view.close();
+     * @name close
+     * @description close the folder manager and its view
+     */
+    public void close () {
+        this.monitor.cancel ();
+        this.view.close ();
     }
 
     /**
-    * @name rename
-    * @description renaming myself
-    * @param string name the new name
-    * @return bool true->everything is ok, false->something failed, rollback
-    */
-    public bool rename(string new_name){
-        if(new_name.length<=0){
+     * @name rename
+     * @description renaming myself
+     * @param string name the new name
+     * @return bool true->everything is ok, false->something failed, rollback
+     */
+    public bool rename (string new_name) {
+        if (new_name.length <= 0) {
             return false;
         }
 
-        var old_name=this.folder_name;
-        var old_path=this.get_absolute_path();
-        this.folder_name=new_name;
-        var new_path=this.get_absolute_path();
-        try{
-            this.settings.name=this.folder_name;
-            this.settings.save();
-            FileUtils.rename(old_path, new_path);
+        var old_name = this.folder_name;
+        var old_path = this.get_absolute_path ();
+        this.folder_name = new_name;
+        var new_path = this.get_absolute_path ();
+        try {
+            this.settings.name = this.folder_name;
+            this.settings.save ();
+            FileUtils.rename (old_path, new_path);
             var directory = File.new_for_path (new_path);
-            if(directory.query_exists ()){
-                //forcing to reload settings
-                this.load_folder_settings();
-                this.sync_files(0,0);
-                this.monitor_folder();
+            if (directory.query_exists ()) {
+                // forcing to reload settings
+                this.load_folder_settings ();
+                this.sync_files (0, 0);
+                this.monitor_folder ();
                 return true;
-            }else{
-                //we can't rename
-                this.folder_name=old_name;
+            } else {
+                // we can't rename
+                this.folder_name = old_name;
                 return false;
             }
-        }catch(Error error){
+        } catch (Error error) {
             stderr.printf ("Error: %s\n", error.message);
-            Util.show_error_dialog("Error",error.message);
+            Util.show_error_dialog ("Error", error.message);
 
-            //we can't rename
-            this.folder_name=old_name;
-            this.settings.name=this.folder_name;
-            this.settings.save();
+            // we can't rename
+            this.folder_name   = old_name;
+            this.settings.name = this.folder_name;
+            this.settings.save ();
             return false;
         }
     }
 
     /**
-    * @name paste
-    * @description paste what ever is in the clipboard (file or folder) to this desktop folder
-    */
-    public void paste(){
-        Clipboard.ClipboardManager cm=Clipboard.ClipboardManager.get_for_display ();
-        if(cm.can_paste){
-            File folder=this.get_file();
-            cm.paste_files(folder,null,null);
+     * @name paste
+     * @description paste what ever is in the clipboard (file or folder) to this desktop folder
+     */
+    public void paste () {
+        Clipboard.ClipboardManager cm = Clipboard.ClipboardManager.get_for_display ();
+        if (cm.can_paste) {
+            File folder = this.get_file ();
+            cm.paste_files (folder, null, null);
         }
     }
 
-
     /**
-    * @name set_new_shape
-    * @description set a new shape (position and size) of the view
-    */
-    public void set_new_shape(int x, int y, int width, int height){
-        this.settings.x=x;
-        this.settings.y=y;
-        this.settings.w=width;
-        this.settings.h=height;
-        this.settings.save();
+     * @name set_new_shape
+     * @description set a new shape (position and size) of the view
+     */
+    public void set_new_shape (int x, int y, int width, int height) {
+        this.settings.x = x;
+        this.settings.y = y;
+        this.settings.w = width;
+        this.settings.h = height;
+        this.settings.save ();
     }
 
     /**
-    * @name save_head_color
-    * @description save a head color to the settings file
-    * @param color string the color for the head to be saved
-    */
-    public void save_head_color(string color){
-        this.settings.fgcolor=color;
-        this.settings.save();
+     * @name save_head_color
+     * @description save a head color to the settings file
+     * @param color string the color for the head to be saved
+     */
+    public void save_head_color (string color) {
+        this.settings.fgcolor = color;
+        this.settings.save ();
     }
 
     /**
-    * @name save_body_color
-    * @description save a body color to the settings file
-    * @param color string the color for the body to be saved
-    */
-    public void save_body_color(string color){
-        this.settings.bgcolor=color;
-        this.settings.save();
+     * @name save_body_color
+     * @description save a body color to the settings file
+     * @param color string the color for the body to be saved
+     */
+    public void save_body_color (string color) {
+        this.settings.bgcolor = color;
+        this.settings.save ();
     }
 
     /**
-    * @name get_absolute_path
-    * @description return the absolute path for this folder
-    * @return the absolute path
-    */
-    public string get_absolute_path(){
-        return DesktopFolderApp.get_app_folder()+"/"+this.folder_name;
+     * @name get_absolute_path
+     * @description return the absolute path for this folder
+     * @return the absolute path
+     */
+    public string get_absolute_path () {
+        return DesktopFolderApp.get_app_folder () + "/" + this.folder_name;
     }
 
     /**
-    * @name get_file
-    * @description return the Glib.File associated with this folder
-    * @return File the File object
-    */
-    private File get_file(){
-        var basePath=this.get_absolute_path();
+     * @name get_file
+     * @description return the Glib.File associated with this folder
+     * @return File the File object
+     */
+    private File get_file () {
+        var  basePath  = this.get_absolute_path ();
         File directory = File.new_for_path (basePath);
         return directory;
     }
 
     /**
-    * @name get_settings
-    * @description return the settings of this folder
-    * @return FolderSettings the settings of this folder
-    */
-    public FolderSettings get_settings(){
+     * @name get_settings
+     * @description return the settings of this folder
+     * @return FolderSettings the settings of this folder
+     */
+    public FolderSettings get_settings () {
         return this.settings;
     }
 
     /**
-    * @name get_view
-    * @description return the FolderWindow view of this manager
-    * @return FolderWindow
-    */
-    public FolderWindow get_view(){
+     * @name get_view
+     * @description return the FolderWindow view of this manager
+     * @return FolderWindow
+     */
+    public FolderWindow get_view () {
         return this.view;
     }
 
-
-    //---------------------------------------------------------------------------------------
-    //---------------------------DndView Implementation--------------------------------------
-    //---------------------------------------------------------------------------------------
-
-    /**
-    * @name get_widget
-    * @description return the widget associated with this view
-    * @return Widget the widget
-    */
-    public Gtk.Widget get_widget(){
-        return this.view;
-    }
+    // ---------------------------------------------------------------------------------------
+    // ---------------------------DndView Implementation--------------------------------------
+    // ---------------------------------------------------------------------------------------
 
     /**
-    * @name get_application_window
-    * @description return the application window of this view, needed for drag operations
-    * @return ApplicationWindow
-    */
-    public Gtk.ApplicationWindow get_application_window(){
+     * @name get_widget
+     * @description return the widget associated with this view
+     * @return Widget the widget
+     */
+    public Gtk.Widget get_widget () {
         return this.view;
     }
 
     /**
-    * @name get_file_at
-    * @name get the file at the position x, y
-    * @return File
-    */
-    public GLib.File get_file_at(int x, int y){
-        return this.get_file();
+     * @name get_application_window
+     * @description return the application window of this view, needed for drag operations
+     * @return ApplicationWindow
+     */
+    public Gtk.ApplicationWindow get_application_window () {
+        return this.view;
     }
 
     /**
-    * @name is_writable
-    * @description indicates if the file linked by this view is writable or not
-    * @return bool
-    */
-    public bool is_writable(){
-        //TODO
+     * @name get_file_at
+     * @name get the file at the position x, y
+     * @return File
+     */
+    public GLib.File get_file_at (int x, int y) {
+        return this.get_file ();
+    }
+
+    /**
+     * @name is_writable
+     * @description indicates if the file linked by this view is writable or not
+     * @return bool
+     */
+    public bool is_writable () {
+        // TODO
         return true;
     }
 
     /**
-    * @name is_folder
-    * @description check whether the view represents a folder or a file
-    * @return bool true->this view represents a folder
-    */
-    public bool is_folder(){
+     * @name is_folder
+     * @description check whether the view represents a folder or a file
+     * @return bool true->this view represents a folder
+     */
+    public bool is_folder () {
         return true;
     }
 
     /**
-    * @name get_target_location
-    * @description return the target File that represents this view
-    * @return File the file target of this view
-    */
-    public GLib.File get_target_location(){
-        return this.get_file();
+     * @name get_target_location
+     * @description return the target File that represents this view
+     * @return File the file target of this view
+     */
+    public GLib.File get_target_location () {
+        return this.get_file ();
     }
 
     /**
-    * @name is_recent_uri_scheme
-    * @description check whether the File is a recent uri scheme?
-    * @return bool
-    */
-    public bool is_recent_uri_scheme(){
+     * @name is_recent_uri_scheme
+     * @description check whether the File is a recent uri scheme?
+     * @return bool
+     */
+    public bool is_recent_uri_scheme () {
         return true;
     }
 
     /**
-    * @name get_display_target_uri
-    * @description return the target uri of this view
-    * @return string the target uri
-    */
-    public string get_display_target_uri(){
-        return DragnDrop.Util.get_display_target_uri(this.get_file());
+     * @name get_display_target_uri
+     * @description return the target uri of this view
+     * @return string the target uri
+     */
+    public string get_display_target_uri () {
+        return DragnDrop.Util.get_display_target_uri (this.get_file ());
     }
 
-    //---------------------------------------------------------------------------------------
-    //---------------------------**********************--------------------------------------
-    //---------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------------------
+    // ---------------------------**********************--------------------------------------
+    // ---------------------------------------------------------------------------------------
 }

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -137,7 +137,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
                 this.settings.save ();
 
                 // we need to rename the affected file/folder
-                for (int i = 0 ; i < this.items.length () ; i++) {
+                for (int i = 0; i < this.items.length (); i++) {
                     ItemManager element = (ItemManager) this.items.nth_data (i);
                     if (element.get_file_name () == old_filename) {
                         element.rename (new_filename);
@@ -319,7 +319,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
                 file.trash ();
                 this.close ();
             } else {
-                for (int i = 0 ; i < this.items.length () ; i++) {
+                for (int i = 0; i < this.items.length (); i++) {
                     this.items.nth_data (i).trash ();
                 }
 

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -309,11 +309,10 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
     }
 
     /**
-     * @name delete
+     * @name trash
      * @description deleting myself!!
      */
-    public void delete () {
-        // lets delete
+    public void trash () {
         try {
             if (this.application.count_widgets () > 1) {
                 File file = File.new_for_path (this.get_absolute_path ());
@@ -321,7 +320,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
                 this.close ();
             } else {
                 for (int i = 0 ; i < this.items.length () ; i++) {
-                    this.items.nth_data (i).delete ();
+                    this.items.nth_data (i).trash ();
                 }
 
                 this.clear_all ();

--- a/src/logic/ItemManager.vala
+++ b/src/logic/ItemManager.vala
@@ -295,10 +295,10 @@ public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.Cl
     }
 
     /**
-     * @name delete
-     * @description delete the file or folder associated
+     * @name trash
+     * @description trash the file or folder associated
      */
-    public void delete () {
+    public void trash () {
         try {
             if (this.is_folder ()) {
                 File file = File.new_for_path (this.get_absolute_path ());

--- a/src/logic/ItemManager.vala
+++ b/src/logic/ItemManager.vala
@@ -1,26 +1,26 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Item Manager that represents an Icon of a File or Folder
-*/
+ * @class
+ * Item Manager that represents an Icon of a File or Folder
+ */
 public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.ClipboardFile {
     /** file name associated with this item */
     private string file_name;
@@ -34,367 +34,367 @@ public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.Cl
     private ItemView view;
 
     /**
-    * @constructor
-    * @param string file_name the name of the file/folder that this item represents
-    * @param File file the GLib File object for the file associated with this item
-    * @param FolderManager folder the folder parent
-    */
-    public ItemManager(string file_name, File file, FolderManager folder){
-        this.file_name=file_name;
-        this.file=file;
-        this.folder=folder;
-        this.selected=false;
-        this.view=new ItemView(this);
+     * @constructor
+     * @param string file_name the name of the file/folder that this item represents
+     * @param File file the GLib File object for the file associated with this item
+     * @param FolderManager folder the folder parent
+     */
+    public ItemManager (string file_name, File file, FolderManager folder) {
+        this.file_name = file_name;
+        this.file      = file;
+        this.folder    = folder;
+        this.selected  = false;
+        this.view      = new ItemView (this);
     }
 
     /**
-    * @name is_selected
-    * @description check if the item is selected or not
-    * @return bool true->the item is selected
-    */
-    public bool is_selected(){
+     * @name is_selected
+     * @description check if the item is selected or not
+     * @return bool true->the item is selected
+     */
+    public bool is_selected () {
         return this.selected;
     }
 
     /**
-    * @name is_link
-    * @description check whether the item is a link to other folder/file or not
-    * @return {bool} true-> yes it is a link
-    */
-    public bool is_link(){
-        var file=this.get_file();
-        var path=file.get_path();
+     * @name is_link
+     * @description check whether the item is a link to other folder/file or not
+     * @return {bool} true-> yes it is a link
+     */
+    public bool is_link () {
+        var file = this.get_file ();
+        var path = file.get_path ();
         return FileUtils.test (path, FileTest.IS_SYMLINK);
     }
 
     /**
-    * @name is_executable
-    * @description check whether the item is a executable
-    * @return {bool} true-> yes it is a executable
-    */
-    public bool is_executable(){
-        var file=this.get_file();
-        var path=file.get_path();
-        if(!this.is_folder()) {
+     * @name is_executable
+     * @description check whether the item is a executable
+     * @return {bool} true-> yes it is a executable
+     */
+    public bool is_executable () {
+        var file = this.get_file ();
+        var path = file.get_path ();
+        if (!this.is_folder ()) {
             return FileUtils.test (path, FileTest.IS_EXECUTABLE);
-        }else{
+        } else {
             return false;
         }
     }
 
     /**
-    * @name select
-    * @description the item is selected
-    */
-    public void select(){
-        this.selected=true;
+     * @name select
+     * @description the item is selected
+     */
+    public void select () {
+        this.selected = true;
     }
 
     /**
-    * @name unselect
-    * @description unselect the item
-    */
-    public void unselect(){
-        this.selected=false;
+     * @name unselect
+     * @description unselect the item
+     */
+    public void unselect () {
+        this.selected = false;
     }
 
     /**
-    * @name change_icon
-    * @description change the icon for the item
-    */
-    public void change_icon(string filename){
-        ItemSettings is=this.folder.get_settings().get_item(this.get_file_name());
-        is.icon=filename;
-        this.folder.get_settings().set_item(is);
-        this.folder.get_settings().save();
-        this.view.refresh_icon();
-    }
-
-
-    /**
-    * @name get_settings
-    * @description return the settings of the item
-    * @return ItemSettings the settings
-    */
-    public ItemSettings get_settings() {
-        return this.folder.get_settings().get_item(this.get_file_name());
+     * @name change_icon
+     * @description change the icon for the item
+     */
+    public void change_icon (string filename) {
+        ItemSettings is = this.folder.get_settings ().get_item (this.get_file_name ());
+        is.icon         = filename;
+        this.folder.get_settings ().set_item (is);
+        this.folder.get_settings ().save ();
+        this.view.refresh_icon ();
     }
 
     /**
-    * @name rename
-    * @description rename the current item (file or folder)
-    * @param new_name string the new name for this item
-    * @return bool true->the operation was succesfull
-    */
-    public bool rename(string new_name){
-        if(new_name.length<=0){
+     * @name get_settings
+     * @description return the settings of the item
+     * @return ItemSettings the settings
+     */
+    public ItemSettings get_settings () {
+        return this.folder.get_settings ().get_item (this.get_file_name ());
+    }
+
+    /**
+     * @name rename
+     * @description rename the current item (file or folder)
+     * @param new_name string the new name for this item
+     * @return bool true->the operation was succesfull
+     */
+    public bool rename (string new_name) {
+        if (new_name.length <= 0) {
             return false;
         }
-        string old_name=this.file_name;
-        string old_path=this.get_absolute_path();
-        this.file_name=new_name;
-        string new_path=this.folder.get_absolute_path()+"/"+new_name;
+        string old_name = this.file_name;
+        string old_path = this.get_absolute_path ();
+        this.file_name = new_name;
+        string new_path = this.folder.get_absolute_path () + "/" + new_name;
 
-        try{
-            this.folder.get_settings().rename(old_name,new_name);
-            this.folder.get_settings().save();
+        try {
+            this.folder.get_settings ().rename (old_name, new_name);
+            this.folder.get_settings ().save ();
 
-            FileUtils.rename(old_path, new_path);
-            this.file=File.new_for_path (new_path);
+            FileUtils.rename (old_path, new_path);
+            this.file = File.new_for_path (new_path);
 
             return false;
-        }catch(Error e){
-            //we can't rename, undoing
-            this.file_name=old_name;
-            ItemSettings is=this.folder.get_settings().get_item(new_name);
-            if(is==null) {
-                is=this.folder.get_settings().get_item(old_name);
+        } catch (Error e) {
+            // we can't rename, undoing
+            this.file_name  = old_name;
+            ItemSettings is = this.folder.get_settings ().get_item (new_name);
+            if (is == null) {
+                is = this.folder.get_settings ().get_item (old_name);
             }
-            this.folder.get_settings().set_item(is);
-            is.name=old_name;
-            this.folder.get_settings().save();
+            this.folder.get_settings ().set_item (is);
+            is.name = old_name;
+            this.folder.get_settings ().save ();
 
-            //showing the error
+            // showing the error
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
 
             return false;
         }
     }
 
     /**
-    * @name save_position
-    * @description save a new position for the item icon at the folder settings
-    * @param int x the x position
-    * @param int y the y position
-    */
-    public void save_position(int x, int y){
-        //the settings need to be modified
-        ItemSettings is=this.folder.get_settings().get_item(this.file_name);
+     * @name save_position
+     * @description save a new position for the item icon at the folder settings
+     * @param int x the x position
+     * @param int y the y position
+     */
+    public void save_position (int x, int y) {
+        // the settings need to be modified
+        ItemSettings is = this.folder.get_settings ().get_item (this.file_name);
         Gtk.Allocation allocation;
-        this.view.get_allocation(out allocation);
-         //HELP! don't know why these constants?? maybe padding??
-        is.x=allocation.x - ItemView.PADDING_X;
-        is.y=allocation.y - ItemView.PADDING_Y;
-        this.folder.get_settings().set_item(is);
-        this.folder.get_settings().save();
+        this.view.get_allocation (out allocation);
+        // HELP! don't know why these constants?? maybe padding??
+        is.x = allocation.x - ItemView.PADDING_X;
+        is.y = allocation.y - ItemView.PADDING_Y;
+        this.folder.get_settings ().set_item (is);
+        this.folder.get_settings ().save ();
     }
 
     /**
-    * @name is_desktop_file
-    * @description check whether the file is a desktop file or not
-    * @return true->yes, it is
-    */
-    public bool is_desktop_file(){
-        int index=this.file_name.index_of(".desktop",0);
-        if(index>0){
+     * @name is_desktop_file
+     * @description check whether the file is a desktop file or not
+     * @return true->yes, it is
+     */
+    public bool is_desktop_file () {
+        int index = this.file_name.index_of (".desktop", 0);
+        if (index > 0) {
             return true;
         }
         return false;
     }
 
     /**
-    * @name execute
-    * @description execute the file associated with this item
-    */
-    public void execute(){
-        //we must launch the file/folder
+     * @name execute
+     * @description execute the file associated with this item
+     */
+    public void execute () {
+        // we must launch the file/folder
         try {
-            if(this.is_desktop_file()){
-                GLib.DesktopAppInfo desktopApp=new GLib.DesktopAppInfo.from_filename(this.get_absolute_path());
-                desktopApp.launch_uris(null,null);
-            }else if(this.is_executable()){
-                var command="\""+this.get_absolute_path()+"\"";
-                var appinfo = AppInfo.create_from_commandline(command,null,AppInfoCreateFlags.NONE);
+            if (this.is_desktop_file ()) {
+                GLib.DesktopAppInfo desktopApp = new GLib.DesktopAppInfo.from_filename (this.get_absolute_path ());
+                desktopApp.launch_uris (null, null);
+            } else if (this.is_executable ())    {
+                var command = "\"" + this.get_absolute_path () + "\"";
+                var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.NONE);
                 appinfo.launch_uris (null, null);
-            }else{
-                var command="xdg-open \""+this.folder.get_absolute_path()+"/"+this.file_name+"\"";
+            } else {
+                var command = "xdg-open \"" + this.folder.get_absolute_path () + "/" + this.file_name + "\"";
                 var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.SUPPORTS_URIS);
                 appinfo.launch_uris (null, null);
             }
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name get_view
-    * @description return the view of this manager
-    * @return ItemView
-    */
-    public ItemView get_view(){
+     * @name get_view
+     * @description return the view of this manager
+     * @return ItemView
+     */
+    public ItemView get_view () {
         return this.view;
     }
 
     /**
-    * @name get_file_name
-    * @description return the file name associated with this item
-    * @return string the file name
-    */
-    public string get_file_name(){
+     * @name get_file_name
+     * @description return the file name associated with this item
+     * @return string the file name
+     */
+    public string get_file_name () {
         return this.file_name;
     }
 
     /**
-    * @name get_file
-    * @description return the Glib.File associated
-    * @return File the file associated
-    */
-    public GLib.File get_file(){
+     * @name get_file
+     * @description return the Glib.File associated
+     * @return File the file associated
+     */
+    public GLib.File get_file () {
         return this.file;
     }
 
     /**
-    * @name get_absolute_path
-    * @description return the absolute path to this item
-    * @return string the absolute path
-    */
-    public string get_absolute_path(){
-        return this.get_file().get_path();
+     * @name get_absolute_path
+     * @description return the absolute path to this item
+     * @return string the absolute path
+     */
+    public string get_absolute_path () {
+        return this.get_file ().get_path ();
     }
 
     /**
-    * @name get_file_type
-    * @description return the FileType of this item
-    * @return FileType
-    */
-    public FileType get_file_type() {
-        File file = this.get_file();
+     * @name get_file_type
+     * @description return the FileType of this item
+     * @return FileType
+     */
+    public FileType get_file_type () {
+        File file = this.get_file ();
         return file.query_file_type (FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
     }
 
     /**
-    * @name is_folder
-    * @description check whether the item is a folder or not
-    * @return bool true->the item is a folder
-    */
-    public bool is_folder(){
-        return FileUtils.test (this.get_absolute_path(), FileTest.IS_DIR);
+     * @name is_folder
+     * @description check whether the item is a folder or not
+     * @return bool true->the item is a folder
+     */
+    public bool is_folder () {
+        return FileUtils.test (this.get_absolute_path (), FileTest.IS_DIR);
     }
 
     /**
-    * @name cut
-    * @description cut the file to the clipboard
-    */
-    public void cut(){
-        Clipboard.ClipboardManager cm=Clipboard.ClipboardManager.get_for_display ();
-        List<Clipboard.ClipboardFile> items=new List<Clipboard.ClipboardFile>();
-        items.append(this);
-        cm.cut_files(items);
+     * @name cut
+     * @description cut the file to the clipboard
+     */
+    public void cut () {
+        Clipboard.ClipboardManager    cm    = Clipboard.ClipboardManager.get_for_display ();
+        List<Clipboard.ClipboardFile> items = new List<Clipboard.ClipboardFile>();
+        items.append (this);
+        cm.cut_files (items);
     }
 
     /**
-    * @name copy
-    * @description copy the file to the clipboard
-    */
-    public void copy(){
-        Clipboard.ClipboardManager cm=Clipboard.ClipboardManager.get_for_display ();
-        List<Clipboard.ClipboardFile> items=new List<Clipboard.ClipboardFile>();
-        items.append(this);
-        cm.copy_files(items);
+     * @name copy
+     * @description copy the file to the clipboard
+     */
+    public void copy () {
+        Clipboard.ClipboardManager    cm    = Clipboard.ClipboardManager.get_for_display ();
+        List<Clipboard.ClipboardFile> items = new List<Clipboard.ClipboardFile>();
+        items.append (this);
+        cm.copy_files (items);
     }
 
     /**
-    * @name delete
-    * @description delete the file or folder associated
-    */
-    public void delete(){
-        try{
-            if(this.is_folder()){
-                File file=File.new_for_path (this.get_absolute_path());
-                file.trash();
-            }else{
-                File file=File.new_for_path (this.get_absolute_path());
-                file.trash();
-                //FileUtils.remove(this.get_absolute_path());
+     * @name delete
+     * @description delete the file or folder associated
+     */
+    public void delete () {
+        try {
+            if (this.is_folder ()) {
+                File file = File.new_for_path (this.get_absolute_path ());
+                file.trash ();
+            } else {
+                File file = File.new_for_path (this.get_absolute_path ());
+                file.trash ();
+                // FileUtils.remove(this.get_absolute_path());
             }
-            this.on_delete();
-        }catch(Error e){
+            this.on_delete ();
+        } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
 
-    //---------------------------------------------------------------------------------------
-    //---------------------------DndView Implementation--------------------------------------
-    //---------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------------------
+    // ---------------------------DndView Implementation--------------------------------------
+    // ---------------------------------------------------------------------------------------
 
     /**
-    * @name get_widget
-    * @description return the widget associated with this view
-    * @return Widget the widget
-    */
-    public Gtk.Widget get_widget(){
+     * @name get_widget
+     * @description return the widget associated with this view
+     * @return Widget the widget
+     */
+    public Gtk.Widget get_widget () {
         return this.view;
     }
 
     /**
-    * @name get_application_window
-    * @description return the application window of this view, needed for drag operations
-    * @return ApplicationWindow
-    */
-    public Gtk.ApplicationWindow get_application_window(){
-        return this.folder.get_view();
+     * @name get_application_window
+     * @description return the application window of this view, needed for drag operations
+     * @return ApplicationWindow
+     */
+    public Gtk.ApplicationWindow get_application_window () {
+        return this.folder.get_view ();
     }
 
     /**
-    * @name get_file_at
-    * @name get the file at the position x, y
-    * @return File
-    */
-    public GLib.File get_file_at(int x, int y){
-        return this.get_file();
+     * @name get_file_at
+     * @name get the file at the position x, y
+     * @return File
+     */
+    public GLib.File get_file_at (int x, int y) {
+        return this.get_file ();
     }
 
     /**
-    * @name is_writable
-    * @description indicates if the file linked by this view is writable or not
-    * @return bool
-    */
-    public bool is_writable(){
-        //TODO
+     * @name is_writable
+     * @description indicates if the file linked by this view is writable or not
+     * @return bool
+     */
+    public bool is_writable () {
+        // TODO
         return true;
     }
 
     /**
-    * @name get_target_location
-    * @description return the target File that represents this view
-    * @return File the file target of this view
-    */
-    public GLib.File get_target_location(){
-        return this.get_file();
+     * @name get_target_location
+     * @description return the target File that represents this view
+     * @return File the file target of this view
+     */
+    public GLib.File get_target_location () {
+        return this.get_file ();
     }
 
     /**
-    * @name is_recent_uri_scheme
-    * @description check whether the File is a recent uri scheme?
-    * @return bool
-    */
-    public bool is_recent_uri_scheme(){
+     * @name is_recent_uri_scheme
+     * @description check whether the File is a recent uri scheme?
+     * @return bool
+     */
+    public bool is_recent_uri_scheme () {
         return true;
     }
 
     /**
-    * @name get_display_target_uri
-    * @description return the target uri of this view
-    * @return string the target uri
-    */
-    public string get_display_target_uri(){
-        return DragnDrop.Util.get_display_target_uri(this.get_file());
+     * @name get_display_target_uri
+     * @description return the target uri of this view
+     * @return string the target uri
+     */
+    public string get_display_target_uri () {
+        return DragnDrop.Util.get_display_target_uri (this.get_file ());
     }
 
-    //---------------------------------------------------------------------------------------
-    //---------------------------**********************--------------------------------------
-    //---------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------------------
+    // ---------------------------**********************--------------------------------------
+    // ---------------------------------------------------------------------------------------
 
     /**
-    * @name get_folder
-    * @description return the folder that contains this item
-    * @return FolderManaget that contains the item.
-    */
-    public FolderManager get_folder(){
+     * @name get_folder
+     * @description return the folder that contains this item
+     * @return FolderManaget that contains the item.
+     */
+    public FolderManager get_folder () {
         return this.folder;
     }
+
 }

--- a/src/logic/ItemManager.vala
+++ b/src/logic/ItemManager.vala
@@ -202,7 +202,7 @@ public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.Cl
             if (this.is_desktop_file ()) {
                 GLib.DesktopAppInfo desktopApp = new GLib.DesktopAppInfo.from_filename (this.get_absolute_path ());
                 desktopApp.launch_uris (null, null);
-            } else if (this.is_executable ())    {
+            } else if (this.is_executable ()) {
                 var command = "\"" + this.get_absolute_path () + "\"";
                 var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.NONE);
                 appinfo.launch_uris (null, null);
@@ -314,7 +314,6 @@ public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.Cl
             Util.show_error_dialog ("Error", e.message);
         }
     }
-
 
     // ---------------------------------------------------------------------------------------
     // ---------------------------DndView Implementation--------------------------------------

--- a/src/logic/NoteManager.vala
+++ b/src/logic/NoteManager.vala
@@ -1,26 +1,26 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Item Manager that represents an Icon of a File or Folder
-*/
+ * @class
+ * Item Manager that represents an Icon of a File or Folder
+ */
 public class DesktopFolder.NoteManager : Object {
     /** parent application */
     private DesktopFolderApp application;
@@ -29,212 +29,210 @@ public class DesktopFolder.NoteManager : Object {
     /** the view associated with this manager */
     private NoteWindow view;
     /** name of the note */
-    private string note_name=null;
+    private string note_name      = null;
     /** Note Settings of this note */
-    private NoteSettings settings=null;
+    private NoteSettings settings = null;
 
     /**
-    * @constructor
-    * @param DesktopFolderApp application the application of this note
-    * @param string note_name the name of the note
-    * @param File file the GLib File object for the file associated with this item
-    */
-    public NoteManager(DesktopFolderApp application, string note_name, File file){
-        this.note_name=note_name;
-        this.file=file;
+     * @constructor
+     * @param DesktopFolderApp application the application of this note
+     * @param string note_name the name of the note
+     * @param File file the GLib File object for the file associated with this item
+     */
+    public NoteManager (DesktopFolderApp application, string note_name, File file) {
+        this.note_name = note_name;
+        this.file      = file;
 
-        //Let's load the settings of the folder (if exist or a new one)
-        this.load_note_settings();
+        // Let's load the settings of the folder (if exist or a new one)
+        this.load_note_settings ();
 
-        //First we create a Note Window above the desktop
-        this.application=application;
-        this.view=new NoteWindow(this);
-        this.application.add_window(this.view);
+        // First we create a Note Window above the desktop
+        this.application = application;
+        this.view        = new NoteWindow (this);
+        this.application.add_window (this.view);
         this.view.show ();
 
-        //trying to put it in front of the rest
-        this.view.set_keep_below(false);
-        this.view.set_keep_above(true);
-        this.view.present();
-        this.view.set_keep_above(false);
-        this.view.set_keep_below(true);
-        //---------------------------------------
+        // trying to put it in front of the rest
+        this.view.set_keep_below (false);
+        this.view.set_keep_above (true);
+        this.view.present ();
+        this.view.set_keep_above (false);
+        this.view.set_keep_below (true);
+        // ---------------------------------------
     }
 
     /**
-    * @name load_note_settings
-    * @description load the settings of this note.
-    * The note/settings file contains all the info needed to create the note position, size, etc.. and the text itself
-    */
-    private void load_note_settings(){
-        //let's search the folder settings file
-        var abs_path=this.get_absolute_path();
-        debug("loading note settings...%s",abs_path);
+     * @name load_note_settings
+     * @description load the settings of this note.
+     * The note/settings file contains all the info needed to create the note position, size, etc.. and the text itself
+     */
+    private void load_note_settings () {
+        // let's search the folder settings file
+        var abs_path = this.get_absolute_path ();
+        debug ("loading note settings...%s", abs_path);
         if (!this.file.query_exists ()) {
-            warning("note file doesnt exist!");
-        }else{
-            NoteSettings existent=NoteSettings.read_settings(this.file, this.get_note_name());
-            this.settings=existent;
+            warning ("note file doesnt exist!");
+        } else {
+            NoteSettings existent = NoteSettings.read_settings (this.file, this.get_note_name ());
+            this.settings = existent;
         }
     }
 
     /**
-    * @name on_text_change
-    * @description the text change event was produced
-    * @param {string} text the new text of the note
-    */
-    public void on_text_change(string text){
-        this.settings.text=text;
-        this.settings.save();
+     * @name on_text_change
+     * @description the text change event was produced
+     * @param {string} text the new text of the note
+     */
+    public void on_text_change (string text) {
+        this.settings.text = text;
+        this.settings.save ();
     }
 
     /**
-    * @name get_settings
-    * @description return the settings of this note
-    * @return FolderSettings the settings of this note
-    */
-    public NoteSettings get_settings(){
+     * @name get_settings
+     * @description return the settings of this note
+     * @return FolderSettings the settings of this note
+     */
+    public NoteSettings get_settings () {
         return this.settings;
     }
 
-
     /**
-    * @name get_note_name
-    * @description return the note name
-    * @return string the note name
-    */
-    public string get_note_name(){
+     * @name get_note_name
+     * @description return the note name
+     * @return string the note name
+     */
+    public string get_note_name () {
         return this.note_name;
     }
 
-
     /**
-    * @name get_application
-    * @description return the desktop folder application
-    * @return DesktopFolderApp
-    */
-    public DesktopFolderApp get_application(){
+     * @name get_application
+     * @description return the desktop folder application
+     * @return DesktopFolderApp
+     */
+    public DesktopFolderApp get_application () {
         return this.application;
     }
 
     /**
-    * @name get_view
-    * @description return the view of this manager
-    * @return ItemView
-    */
-    public NoteWindow get_view(){
+     * @name get_view
+     * @description return the view of this manager
+     * @return ItemView
+     */
+    public NoteWindow get_view () {
         return this.view;
     }
 
     /**
-    * @name get_file
-    * @description return the Glib.File associated
-    * @return File the file associated
-    */
-    public GLib.File get_file(){
+     * @name get_file
+     * @description return the Glib.File associated
+     * @return File the file associated
+     */
+    public GLib.File get_file () {
         return this.file;
     }
 
     /**
-    * @name get_absolute_path
-    * @description return the absolute path to this item
-    * @return string the absolute path
-    */
-    public string get_absolute_path(){
-        return this.get_file().get_path();
+     * @name get_absolute_path
+     * @description return the absolute path to this item
+     * @return string the absolute path
+     */
+    public string get_absolute_path () {
+        return this.get_file ().get_path ();
     }
 
     /**
-    * @name close
-    * @description close the item manager and its view
-    */
-    public void close(){
-        this.view.close();
+     * @name close
+     * @description close the item manager and its view
+     */
+    public void close () {
+        this.view.close ();
     }
 
-
     /**
-    * @name delete
-    * @description delete the file or folder associated
-    */
-    public void delete(){
-        try{
-            File file=File.new_for_path (this.get_absolute_path());
-            file.trash();
-        }catch(Error e){
+     * @name delete
+     * @description delete the file or folder associated
+     */
+    public void delete () {
+        try {
+            File file = File.new_for_path (this.get_absolute_path ());
+            file.trash ();
+        } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name set_new_shape
-    * @description set a new shape (position and size) of the view
-    */
-    public void set_new_shape(int x, int y, int width, int height){
-        this.settings.x=x;
-        this.settings.y=y;
-        this.settings.w=width;
-        this.settings.h=height;
-        this.settings.save();
+     * @name set_new_shape
+     * @description set a new shape (position and size) of the view
+     */
+    public void set_new_shape (int x, int y, int width, int height) {
+        this.settings.x = x;
+        this.settings.y = y;
+        this.settings.w = width;
+        this.settings.h = height;
+        this.settings.save ();
     }
 
     /**
-    * @name save_head_color
-    * @description save a head color to the settings file
-    * @param color string the color for the head to be saved
-    */
-    public void save_head_color(string color){
-        this.settings.fgcolor=color;
-        this.settings.save();
+     * @name save_head_color
+     * @description save a head color to the settings file
+     * @param color string the color for the head to be saved
+     */
+    public void save_head_color (string color) {
+        this.settings.fgcolor = color;
+        this.settings.save ();
     }
 
     /**
-    * @name save_body_color
-    * @description save a body color to the settings file
-    * @param color string the color for the body to be saved
-    */
-    public void save_body_color(string color){
-        this.settings.bgcolor=color;
-        this.settings.save();
+     * @name save_body_color
+     * @description save a body color to the settings file
+     * @param color string the color for the body to be saved
+     */
+    public void save_body_color (string color) {
+        this.settings.bgcolor = color;
+        this.settings.save ();
     }
 
     /**
-    * @name rename
-    * @description renaming myself
-    * @param string name the new name
-    * @return bool true->everything is ok, false->something failed, rollback
-    */
-    public bool rename(string new_name){
-        if(new_name.length<=0){
+     * @name rename
+     * @description renaming myself
+     * @param string name the new name
+     * @return bool true->everything is ok, false->something failed, rollback
+     */
+    public bool rename (string new_name) {
+        if (new_name.length <= 0) {
             return false;
         }
-        string old_name=this.note_name;
-        string old_path=this.get_absolute_path();
-        this.note_name=new_name;
-        string new_path=DesktopFolderApp.get_app_folder()+"/"+new_name+"."+DesktopFolder.NOTE_EXTENSION;
+        string old_name = this.note_name;
+        string old_path = this.get_absolute_path ();
+        this.note_name = new_name;
+        string new_path = DesktopFolderApp.get_app_folder () + "/" + new_name + "." + DesktopFolder.NOTE_EXTENSION;
 
-        try{
-            NoteSettings is=this.get_settings();
-            is.name=new_name;
+        try {
+            NoteSettings is = this.get_settings ();
+            is.name         = new_name;
 
-            FileUtils.rename(old_path, new_path);
-            this.file=File.new_for_path (new_path);
-            is.save_to_file(this.file);
+            FileUtils.rename (old_path, new_path);
+            this.file = File.new_for_path (new_path);
+            is.save_to_file (this.file);
 
             return true;
-        }catch(Error e){
-            //we can't rename, undoing
-            this.note_name=old_name;
-            NoteSettings is=this.get_settings();
-            is.name=old_name;
-            is.save();
+        } catch (Error e) {
+            // we can't rename, undoing
+            this.note_name  = old_name;
+            NoteSettings is = this.get_settings ();
+            is.name         = old_name;
+            is.save ();
 
-            //showing the error
+            // showing the error
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
 
             return false;
         }
     }
+
 }

--- a/src/logic/NoteManager.vala
+++ b/src/logic/NoteManager.vala
@@ -151,10 +151,10 @@ public class DesktopFolder.NoteManager : Object {
     }
 
     /**
-     * @name delete
-     * @description delete the file or folder associated
+     * @name trash
+     * @description trash the file or folder associated
      */
-    public void delete () {
+    public void trash () {
         try {
             File file = File.new_for_path (this.get_absolute_path ());
             file.trash ();

--- a/src/logic/PhotoManager.vala
+++ b/src/logic/PhotoManager.vala
@@ -1,26 +1,26 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Item Manager that represents an Icon of a File or Folder
-*/
+ * @class
+ * Item Manager that represents an Icon of a File or Folder
+ */
 public class DesktopFolder.PhotoManager : Object {
     /** parent application */
     private DesktopFolderApp application;
@@ -29,182 +29,180 @@ public class DesktopFolder.PhotoManager : Object {
     /** the view associated with this manager */
     private PhotoWindow view;
     /** name of the photo */
-    private string photo_name=null;
+    private string photo_name      = null;
     /** photo Settings of this photo */
-    private PhotoSettings settings=null;
+    private PhotoSettings settings = null;
 
     /**
-    * @constructor
-    * @param DesktopFolderApp application the application of this photo
-    * @param string photo_name the name of the photo
-    * @param File file the GLib File object for the file associated with this item
-    */
-    public PhotoManager(DesktopFolderApp application, string photo_name, File file){
-        this.photo_name=photo_name;
-        this.file=file;
+     * @constructor
+     * @param DesktopFolderApp application the application of this photo
+     * @param string photo_name the name of the photo
+     * @param File file the GLib File object for the file associated with this item
+     */
+    public PhotoManager (DesktopFolderApp application, string photo_name, File file) {
+        this.photo_name = photo_name;
+        this.file       = file;
 
-        //Let's load the settings of the folder (if exist or a new one)
-        this.load_photo_settings();
+        // Let's load the settings of the folder (if exist or a new one)
+        this.load_photo_settings ();
 
-        //First we create a photo Window above the desktop
-        this.application=application;
-        this.view=new PhotoWindow(this);
-        this.application.add_window(this.view);
+        // First we create a photo Window above the desktop
+        this.application = application;
+        this.view        = new PhotoWindow (this);
+        this.application.add_window (this.view);
         this.view.show ();
 
-        //trying to put it in front of the rest
-        this.view.set_keep_below(false);
-        this.view.set_keep_above(true);
-        this.view.present();
-        this.view.set_keep_above(false);
-        this.view.set_keep_below(true);
-        //---------------------------------------
+        // trying to put it in front of the rest
+        this.view.set_keep_below (false);
+        this.view.set_keep_above (true);
+        this.view.present ();
+        this.view.set_keep_above (false);
+        this.view.set_keep_below (true);
+        // ---------------------------------------
     }
 
     /**
-    * @name load_photo_settings
-    * @description load the settings of this photo.
-    * The photo/settings file contains all the info needed to create the photo position, size, etc.. and the text itself
-    */
-    private void load_photo_settings(){
-        //let's search the folder settings file
-        var abs_path=this.get_absolute_path();
-        debug("loading photo settings...%s",abs_path);
+     * @name load_photo_settings
+     * @description load the settings of this photo.
+     * The photo/settings file contains all the info needed to create the photo position, size, etc.. and the text itself
+     */
+    private void load_photo_settings () {
+        // let's search the folder settings file
+        var abs_path = this.get_absolute_path ();
+        debug ("loading photo settings...%s", abs_path);
         if (!this.file.query_exists ()) {
-            warning("photo file doesnt exist!");
-        }else{
-            PhotoSettings existent=PhotoSettings.read_settings(this.file, this.get_photo_name());
-            this.settings=existent;
+            warning ("photo file doesnt exist!");
+        } else {
+            PhotoSettings existent = PhotoSettings.read_settings (this.file, this.get_photo_name ());
+            this.settings = existent;
         }
     }
 
     /**
-    * @name get_settings
-    * @description return the settings of this photo
-    * @return PhotoSettings the settings of this photo
-    */
-    public PhotoSettings get_settings(){
+     * @name get_settings
+     * @description return the settings of this photo
+     * @return PhotoSettings the settings of this photo
+     */
+    public PhotoSettings get_settings () {
         return this.settings;
     }
 
-
     /**
-    * @name get_photo_name
-    * @description return the photo name
-    * @return string the photo name
-    */
-    public string get_photo_name(){
+     * @name get_photo_name
+     * @description return the photo name
+     * @return string the photo name
+     */
+    public string get_photo_name () {
         return this.photo_name;
     }
 
-
     /**
-    * @name get_application
-    * @description return the desktop folder application
-    * @return DesktopFolderApp
-    */
-    public DesktopFolderApp get_application(){
+     * @name get_application
+     * @description return the desktop folder application
+     * @return DesktopFolderApp
+     */
+    public DesktopFolderApp get_application () {
         return this.application;
     }
 
     /**
-    * @name get_view
-    * @description return the view of this manager
-    * @return PhotoWindow
-    */
-    public PhotoWindow get_view(){
+     * @name get_view
+     * @description return the view of this manager
+     * @return PhotoWindow
+     */
+    public PhotoWindow get_view () {
         return this.view;
     }
 
     /**
-    * @name get_file
-    * @description return the Glib.File associated
-    * @return File the file associated
-    */
-    public GLib.File get_file(){
+     * @name get_file
+     * @description return the Glib.File associated
+     * @return File the file associated
+     */
+    public GLib.File get_file () {
         return this.file;
     }
 
     /**
-    * @name get_absolute_path
-    * @description return the absolute path to this item
-    * @return string the absolute path
-    */
-    public string get_absolute_path(){
-        return this.get_file().get_path();
+     * @name get_absolute_path
+     * @description return the absolute path to this item
+     * @return string the absolute path
+     */
+    public string get_absolute_path () {
+        return this.get_file ().get_path ();
     }
 
     /**
-    * @name close
-    * @description close the item manager and its view
-    */
-    public void close(){
-        this.view.close();
+     * @name close
+     * @description close the item manager and its view
+     */
+    public void close () {
+        this.view.close ();
     }
 
-
     /**
-    * @name delete
-    * @description delete the file associated
-    */
-    public void delete(){
-        try{
-            File file=File.new_for_path (this.get_absolute_path());
-            file.trash();
-        }catch(Error e){
+     * @name delete
+     * @description delete the file associated
+     */
+    public void delete () {
+        try {
+            File file = File.new_for_path (this.get_absolute_path ());
+            file.trash ();
+        } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name set_new_shape
-    * @description set a new shape (position and size) of the view
-    */
-    public void set_new_shape(int x, int y, int width, int height){
-        this.settings.x=x;
-        this.settings.y=y;
-        this.settings.w=width;
-        this.settings.h=height;
-        this.settings.save();
+     * @name set_new_shape
+     * @description set a new shape (position and size) of the view
+     */
+    public void set_new_shape (int x, int y, int width, int height) {
+        this.settings.x = x;
+        this.settings.y = y;
+        this.settings.w = width;
+        this.settings.h = height;
+        this.settings.save ();
     }
 
     /**
-    * @name rename
-    * @description renaming myself
-    * @param string name the new name
-    * @return bool true->everything is ok, false->something failed, rollback
-    */
-    public bool rename(string new_name){
-        if(new_name.length<=0){
+     * @name rename
+     * @description renaming myself
+     * @param string name the new name
+     * @return bool true->everything is ok, false->something failed, rollback
+     */
+    public bool rename (string new_name) {
+        if (new_name.length <= 0) {
             return false;
         }
-        string old_name=this.photo_name;
-        string old_path=this.get_absolute_path();
-        this.photo_name=new_name;
-        string new_path=DesktopFolderApp.get_app_folder()+"/"+new_name+"."+DesktopFolder.PHOTO_EXTENSION;
+        string old_name = this.photo_name;
+        string old_path = this.get_absolute_path ();
+        this.photo_name = new_name;
+        string new_path = DesktopFolderApp.get_app_folder () + "/" + new_name + "." + DesktopFolder.PHOTO_EXTENSION;
 
-        try{
-            PhotoSettings is=this.get_settings();
-            is.name=new_name;
+        try {
+            PhotoSettings is = this.get_settings ();
+            is.name          = new_name;
 
-            FileUtils.rename(old_path, new_path);
-            this.file=File.new_for_path (new_path);
-            is.save_to_file(this.file);
+            FileUtils.rename (old_path, new_path);
+            this.file = File.new_for_path (new_path);
+            is.save_to_file (this.file);
 
             return true;
-        }catch(Error e){
-            //we can't rename, undoing
-            this.photo_name=old_name;
-            PhotoSettings is=this.get_settings();
-            is.name=old_name;
-            is.save();
+        } catch (Error e) {
+            // we can't rename, undoing
+            this.photo_name  = old_name;
+            PhotoSettings is = this.get_settings ();
+            is.name          = old_name;
+            is.save ();
 
-            //showing the error
+            // showing the error
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
 
             return false;
         }
     }
+
 }

--- a/src/logic/PhotoManager.vala
+++ b/src/logic/PhotoManager.vala
@@ -147,7 +147,7 @@ public class DesktopFolder.PhotoManager : Object {
     public void delete () {
         try {
             File file = File.new_for_path (this.get_absolute_path ());
-            file.trash ();
+            file.delete ();
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
             Util.show_error_dialog ("Error", e.message);

--- a/src/settings/FolderSettings.vala
+++ b/src/settings/FolderSettings.vala
@@ -71,7 +71,7 @@ public class DesktopFolder.FolderSettings : Object {
     public void set_item (ItemSettings item) {
         // first, we create the list of itemsettings, and replace the old with the new one content
         List<ItemSettings> all = new List<ItemSettings>();
-        for (int i = 0 ; i < this.items.length ; i++) {
+        for (int i = 0; i < this.items.length; i++) {
             ItemSettings is = ItemSettings.parse (this.items[i]);
             if (is.name == item.name) {
                 is = item;
@@ -81,7 +81,7 @@ public class DesktopFolder.FolderSettings : Object {
 
         // finally, we recreate the string[]
         string[] str_result = new string[all.length ()];
-        for (int i = 0 ; i < all.length () ; i++) {
+        for (int i = 0; i < all.length (); i++) {
             ItemSettings element = all.nth_data (i);
             var          str     = element.to_string ();
             str_result[i] = str;
@@ -98,7 +98,7 @@ public class DesktopFolder.FolderSettings : Object {
     public void rename (string oldName, string newName) {
         // first, we create the list of itemsettings, and replace the old with the new one content
         List<ItemSettings> all = new List<ItemSettings>();
-        for (int i = 0 ; i < this.items.length ; i++) {
+        for (int i = 0; i < this.items.length; i++) {
             ItemSettings is = ItemSettings.parse (this.items[i]);
             if (is.name == oldName) {
                 is.name = newName;
@@ -108,7 +108,7 @@ public class DesktopFolder.FolderSettings : Object {
 
         // finally, we recreate the string[]
         string[] str_result = new string[all.length ()];
-        for (int i = 0 ; i < all.length () ; i++) {
+        for (int i = 0; i < all.length (); i++) {
             ItemSettings element = all.nth_data (i);
             var          str     = element.to_string ();
             str_result[i] = str;
@@ -129,7 +129,7 @@ public class DesktopFolder.FolderSettings : Object {
 
         // alternative, copying it manually?!! :(
         string[] citems = new string[length + 1];
-        for (int i = 0 ; i < length ; i++) {
+        for (int i = 0; i < length; i++) {
             citems[i] = this.items[i];
         }
         citems[length] = item.to_string ();
@@ -143,7 +143,7 @@ public class DesktopFolder.FolderSettings : Object {
      * @return ItemSettings the ItemSettings found
      */
     public ItemSettings get_item (string name) {
-        for (int i = 0 ; i < this.items.length ; i++) {
+        for (int i = 0; i < this.items.length; i++) {
             ItemSettings is = ItemSettings.parse (this.items[i]);
             if (is.name == name) {
                 return is;
@@ -236,7 +236,7 @@ public class DesktopFolder.FolderSettings : Object {
      */
     public void check_all () {
         List<ItemSettings> all = new List<ItemSettings>();
-        for (int i = 0 ; i < this.items.length ; i++) {
+        for (int i = 0; i < this.items.length; i++) {
             ItemSettings is = ItemSettings.parse (this.items[i]);
             var basePath = Environment.get_home_dir () + "/Desktop/" + this.name;
             var filepath = basePath + "/" + is.name;
@@ -252,7 +252,7 @@ public class DesktopFolder.FolderSettings : Object {
 
         // finally, we recreate the string[]
         string[] str_result = new string[all.length ()];
-        for (int i = 0 ; i < all.length () ; i++) {
+        for (int i = 0; i < all.length (); i++) {
             ItemSettings element = all.nth_data (i);
             var          str     = element.to_string ();
             str_result[i] = str;

--- a/src/settings/FolderSettings.vala
+++ b/src/settings/FolderSettings.vala
@@ -1,151 +1,151 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Desktop Folder Settings
-*/
-public class DesktopFolder.FolderSettings: Object{
-    public int x  { get; set; default = 0; }
-    public int y  { get; set; default = 0; }
-    public int w  { get; set; default = 0; }
-    public int h  { get; set; default = 0; }
-    public string name { get; set; }
-    public string bgcolor { get; set; }
-    public string fgcolor { get; set; }
-    public bool textbold { get; set; }
-    public bool textshadow {get; set; }
-    public bool align_to_grid {get; set; default=false;}
-    public string[] items { get; set; default = new string[0]; }
-    //default json seralization implementation only support primitive types
+ * @class
+ * Desktop Folder Settings
+ */
+public class DesktopFolder.FolderSettings : Object {
+    public int x  { get;set;default = 0; }
+    public int y  { get;set;default = 0; }
+    public int w  { get;set;default = 0; }
+    public int h  { get;set;default = 0; }
+    public string name { get;set; }
+    public string bgcolor { get;set; }
+    public string fgcolor { get;set; }
+    public bool textbold { get;set; }
+    public bool textshadow { get;set; }
+    public bool align_to_grid { get;set;default = false; }
+    public string[] items { get;set;default = new string[0]; }
+    // default json seralization implementation only support primitive types
 
     private File file;
 
     /**
-    * @Constructor
-    * @param string name the name of the folder
-    */
+     * @Constructor
+     * @param string name the name of the folder
+     */
     public FolderSettings (string name) {
-        this.reset();
-	}
-
-    /**
-    * @name reset
-    * @description reset the properties
-    */
-    public void reset(){
-        this.x=100;
-        this.y=100;
-        this.w=300;
-        this.h=300;
-        this.bgcolor="df_black";
-        this.fgcolor="df_light";
-        this.textbold=true;
-        this.textshadow=true;
-        this.align_to_grid=false;
-        this.name=name;
-        this.items=new string[0];
+        this.reset ();
     }
 
     /**
-    * @name set_item
-    * @description replace the current settings for a certain item with other new info
-    * @param ItemSettings item the new settings for the item with the same name
-    */
-    public void set_item(ItemSettings item){
-        //first, we create the list of itemsettings, and replace the old with the new one content
-        List<ItemSettings> all=new List<ItemSettings>();
-        for(int i=0;i<this.items.length;i++){
-            ItemSettings is=ItemSettings.parse(this.items[i]);
-            if(is.name==item.name){
-                is=item;
+     * @name reset
+     * @description reset the properties
+     */
+    public void reset () {
+        this.x             = 100;
+        this.y             = 100;
+        this.w             = 300;
+        this.h             = 300;
+        this.bgcolor       = "df_black";
+        this.fgcolor       = "df_light";
+        this.textbold      = true;
+        this.textshadow    = true;
+        this.align_to_grid = false;
+        this.name          = name;
+        this.items         = new string[0];
+    }
+
+    /**
+     * @name set_item
+     * @description replace the current settings for a certain item with other new info
+     * @param ItemSettings item the new settings for the item with the same name
+     */
+    public void set_item (ItemSettings item) {
+        // first, we create the list of itemsettings, and replace the old with the new one content
+        List<ItemSettings> all = new List<ItemSettings>();
+        for (int i = 0 ; i < this.items.length ; i++) {
+            ItemSettings is = ItemSettings.parse (this.items[i]);
+            if (is.name == item.name) {
+                is = item;
             }
-            all.append(is);
+            all.append (is);
         }
 
-        //finally, we recreate the string[]
-        string[] str_result=new string[all.length()];
-        for(int i=0;i<all.length();i++) {
-            ItemSettings element=all.nth_data(i);
-            var str=element.to_string();
-            str_result[i]=str;
+        // finally, we recreate the string[]
+        string[] str_result = new string[all.length ()];
+        for (int i = 0 ; i < all.length () ; i++) {
+            ItemSettings element = all.nth_data (i);
+            var          str     = element.to_string ();
+            str_result[i] = str;
         }
-        this.items=str_result;
+        this.items = str_result;
     }
 
     /**
-    * @name rename
-    * @description rename an item on this folder.
-    * @param oldName string the old name of the item
-    * @param newName string the new name of the item
-    */
-    public void rename(string oldName, string newName){
-        //first, we create the list of itemsettings, and replace the old with the new one content
-        List<ItemSettings> all=new List<ItemSettings>();
-        for(int i=0;i<this.items.length;i++){
-            ItemSettings is=ItemSettings.parse(this.items[i]);
-            if(is.name==oldName){
-                is.name=newName;
+     * @name rename
+     * @description rename an item on this folder.
+     * @param oldName string the old name of the item
+     * @param newName string the new name of the item
+     */
+    public void rename (string oldName, string newName) {
+        // first, we create the list of itemsettings, and replace the old with the new one content
+        List<ItemSettings> all = new List<ItemSettings>();
+        for (int i = 0 ; i < this.items.length ; i++) {
+            ItemSettings is = ItemSettings.parse (this.items[i]);
+            if (is.name == oldName) {
+                is.name = newName;
             }
-            all.append(is);
+            all.append (is);
         }
 
-        //finally, we recreate the string[]
-        string[] str_result=new string[all.length()];
-        for(int i=0;i<all.length();i++) {
-            ItemSettings element=all.nth_data(i);
-            var str=element.to_string();
-            str_result[i]=str;
+        // finally, we recreate the string[]
+        string[] str_result = new string[all.length ()];
+        for (int i = 0 ; i < all.length () ; i++) {
+            ItemSettings element = all.nth_data (i);
+            var          str     = element.to_string ();
+            str_result[i] = str;
         }
-        this.items=str_result;
+        this.items = str_result;
     }
 
     /**
-    * @name add_item
-    * @description add an item setting to the list of items of this folder settings
-    * @param item ItemSettings the ItemSettings to be added
-    */
-    public void add_item(ItemSettings item){
-        int length=this.items.length;
-        //i don't know why this can't compile
-        //this.items.resize(length+1);
-        //this.items[this.items.length-1]=item.to_string();
+     * @name add_item
+     * @description add an item setting to the list of items of this folder settings
+     * @param item ItemSettings the ItemSettings to be added
+     */
+    public void add_item (ItemSettings item) {
+        int length = this.items.length;
+        // i don't know why this can't compile
+        // this.items.resize(length+1);
+        // this.items[this.items.length-1]=item.to_string();
 
-        //alternative, copying it manually?!! :(
-        string[] citems=new string[length+1];
-        for(int i=0;i<length;i++){
-            citems[i]=this.items[i];
+        // alternative, copying it manually?!! :(
+        string[] citems = new string[length + 1];
+        for (int i = 0 ; i < length ; i++) {
+            citems[i] = this.items[i];
         }
-        citems[length]=item.to_string();
-        this.items=citems;
+        citems[length] = item.to_string ();
+        this.items     = citems;
     }
 
     /**
-    * @name get_item
-    * @description get an ItemSettings of an existent item inside this folder
-    * @param name string the name to find the item
-    * @return ItemSettings the ItemSettings found
-    */
-    public ItemSettings get_item(string name){
-        for(int i=0;i<this.items.length;i++){
-            ItemSettings is=ItemSettings.parse(this.items[i]);
-            if(is.name==name){
+     * @name get_item
+     * @description get an ItemSettings of an existent item inside this folder
+     * @param name string the name to find the item
+     * @return ItemSettings the ItemSettings found
+     */
+    public ItemSettings get_item (string name) {
+        for (int i = 0 ; i < this.items.length ; i++) {
+            ItemSettings is = ItemSettings.parse (this.items[i]);
+            if (is.name == name) {
                 return is;
             }
         }
@@ -153,31 +153,31 @@ public class DesktopFolder.FolderSettings: Object{
     }
 
     /**
-    * @name save
-    * @description persist the changes to the filesystem. The File is the same as the saved initially.
-    */
-    public void save(){
-        this.save_to_file(this.file);
+     * @name save
+     * @description persist the changes to the filesystem. The File is the same as the saved initially.
+     */
+    public void save () {
+        this.save_to_file (this.file);
     }
 
     /**
-    * @name save_to_file
-    * @description persist the changes to the filesystem. The file used is passed to the function, and saved for following saves.
-    * @param file File the file to be saved
-    */
-    public void save_to_file(File file){
-        this.file=file;
-        //string data = Json.gobject_to_data (this, null);
+     * @name save_to_file
+     * @description persist the changes to the filesystem. The file used is passed to the function, and saved for following saves.
+     * @param file File the file to be saved
+     */
+    public void save_to_file (File file) {
+        this.file = file;
+        // string data = Json.gobject_to_data (this, null);
         Json.Node root = Json.gobject_serialize (this);
 
-    	// To string: (see gobject_to_data)
-    	Json.Generator generator = new Json.Generator ();
-    	generator.set_root (root);
-    	string data = generator.to_data (null);
+        // To string: (see gobject_to_data)
+        Json.Generator generator = new Json.Generator ();
+        generator.set_root (root);
+        string data              = generator.to_data (null);
 
         try {
             // an output file in the current working directory
-             if (file.query_exists ()) {
+            if (file.query_exists ()) {
                 file.delete ();
             }
 
@@ -185,7 +185,7 @@ public class DesktopFolder.FolderSettings: Object{
             /*
                 Use BufferedOutputStream to increase write speed:
                 var dos = new DataOutputStream (new BufferedOutputStream.sized (file.create (FileCreateFlags.REPLACE_DESTINATION), 65536));
-            */
+             */
             var dos = new DataOutputStream (file.create (FileCreateFlags.REPLACE_DESTINATION));
             // writing a short string to the stream
             dos.put_string (data);
@@ -196,33 +196,33 @@ public class DesktopFolder.FolderSettings: Object{
     }
 
     /**
-    * @name read_settings
-    * @description read the settings from a file to create a Folder Settings object
-    * @param file File the file where the settings are persisted
-    * @param name string the name of the folder
-    * @return FolderSettings the FolderSettings created
-    */
-    public static FolderSettings read_settings(File file, string name) {
-        try{
-            string content="";
-            var dis = new DataInputStream (file.read());
+     * @name read_settings
+     * @description read the settings from a file to create a Folder Settings object
+     * @param file File the file where the settings are persisted
+     * @param name string the name of the folder
+     * @return FolderSettings the FolderSettings created
+     */
+    public static FolderSettings read_settings (File file, string name) {
+        try {
+            string content = "";
+            var    dis     = new DataInputStream (file.read ());
             string line;
             // Read lines until end of file (null) is reached
             while ((line = dis.read_line (null)) != null) {
-                content=content+line;
+                content = content + line;
             }
             FolderSettings existent = Json.gobject_from_data (typeof (FolderSettings), content) as FolderSettings;
-            existent.file=file;
-            existent.name=name;
+            existent.file = file;
+            existent.name = name;
 
-            //regression for classes, now must have a df_ prefix
-            if(existent.bgcolor.length>0 && !existent.bgcolor.has_prefix("df_")){
-                existent.bgcolor="df_"+existent.bgcolor;
+            // regression for classes, now must have a df_ prefix
+            if (existent.bgcolor.length > 0 && !existent.bgcolor.has_prefix ("df_")) {
+                existent.bgcolor = "df_" + existent.bgcolor;
             }
-            if(existent.fgcolor.length>0 && !existent.fgcolor.has_prefix("df_")){
-                existent.fgcolor="df_"+existent.fgcolor;
+            if (existent.fgcolor.length > 0 && !existent.fgcolor.has_prefix ("df_")) {
+                existent.fgcolor = "df_" + existent.fgcolor;
             }
-            existent.check_all();
+            existent.check_all ();
             return existent;
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
@@ -231,35 +231,36 @@ public class DesktopFolder.FolderSettings: Object{
     }
 
     /**
-    * @name check_all
-    * @description check if all the items described exists fisically, and fixes problems
-    */
-    public void check_all(){
-        List<ItemSettings> all=new List<ItemSettings>();
-        for(int i=0;i<this.items.length;i++){
-            ItemSettings is=ItemSettings.parse(this.items[i]);
-            var basePath=Environment.get_home_dir ()+"/Desktop/"+this.name;
-            var filepath=basePath+"/"+is.name;
-            //debug("checking:"+filepath);
-            File f=File.new_for_path (filepath);
+     * @name check_all
+     * @description check if all the items described exists fisically, and fixes problems
+     */
+    public void check_all () {
+        List<ItemSettings> all = new List<ItemSettings>();
+        for (int i = 0 ; i < this.items.length ; i++) {
+            ItemSettings is = ItemSettings.parse (this.items[i]);
+            var basePath = Environment.get_home_dir () + "/Desktop/" + this.name;
+            var filepath = basePath + "/" + is.name;
+            // debug("checking:"+filepath);
+            File f       = File.new_for_path (filepath);
             if (f.query_exists ()) {
-                    all.append(is);
-            }else{
-                debug("Alert! doesnt exist: %s",filepath);
-                //doesn't exist, we must remove the entry
+                all.append (is);
+            } else {
+                debug ("Alert! doesnt exist: %s", filepath);
+                // doesn't exist, we must remove the entry
             }
         }
 
-        //finally, we recreate the string[]
-        string[] str_result=new string[all.length()];
-        for(int i=0;i<all.length();i++) {
-            ItemSettings element=all.nth_data(i);
-            var str=element.to_string();
-            str_result[i]=str;
+        // finally, we recreate the string[]
+        string[] str_result = new string[all.length ()];
+        for (int i = 0 ; i < all.length () ; i++) {
+            ItemSettings element = all.nth_data (i);
+            var          str     = element.to_string ();
+            str_result[i] = str;
         }
-        this.items=str_result;
+        this.items = str_result;
 
-        //and we finally resave it
-        this.save();
+        // and we finally resave it
+        this.save ();
     }
+
 }

--- a/src/settings/ItemSettings.vala
+++ b/src/settings/ItemSettings.vala
@@ -1,69 +1,70 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Item Settings
-*/
-public class DesktopFolder.ItemSettings: Object{
+ * @class
+ * Item Settings
+ */
+public class DesktopFolder.ItemSettings : Object {
     /** the name of the item*/
-    public string name {get; set;}
+    public string name { get;set; }
     /** x position */
-    public int x { get; set; }
+    public int x { get;set; }
     /** y position */
-    public int y { get; set; }
+    public int y { get;set; }
     /** the icon for this file */
-    public string icon{get; set;}
+    public string icon { get;set; }
 
     /**
-    * @constructor
-    */
+     * @constructor
+     */
     public ItemSettings () {
-        this.name="helloWorld.txt";
-        this.x=5;
-        this.x=5;
-        this.icon="";
-	}
-
-    /**
-    * @name to_string
-    * @description convert to string the item
-    */
-    public string to_string(){
-        return "%s;%d;%d;%s".printf(this.name,this.x ,this.y,this.icon);
+        this.name = "helloWorld.txt";
+        this.x    = 5;
+        this.x    = 5;
+        this.icon = "";
     }
 
     /**
-    * @name parse
-    * @description parse an string to create an ItemSettings object
-    * @param data string the data to be parsed
-    * @return ItemSettings the ItemSettings created
-    */
-    public static ItemSettings parse(string data){
-        ItemSettings result=new ItemSettings();
-        string[] split=data.split(";");
-        result.name=split[0];
-        result.x=int.parse(split[1]);
-        result.y=int.parse(split[2]);
-        if(split.length>3){
-            result.icon=split[3];
+     * @name to_string
+     * @description convert to string the item
+     */
+    public string to_string () {
+        return "%s;%d;%d;%s".printf (this.name, this.x, this.y, this.icon);
+    }
+
+    /**
+     * @name parse
+     * @description parse an string to create an ItemSettings object
+     * @param data string the data to be parsed
+     * @return ItemSettings the ItemSettings created
+     */
+    public static ItemSettings parse (string data) {
+        ItemSettings result = new ItemSettings ();
+        string[]     split  = data.split (";");
+        result.name = split[0];
+        result.x    = int.parse (split[1]);
+        result.y    = int.parse (split[2]);
+        if (split.length > 3) {
+            result.icon = split[3];
         }
         return result;
     }
+
 }

--- a/src/settings/NoteSettings.vala
+++ b/src/settings/NoteSettings.vala
@@ -1,55 +1,55 @@
-public class DesktopFolder.NoteSettings: Object{
-    public int x  { get; set; default = 0; }
-    public int y  { get; set; default = 0; }
-    public int w  { get; set; default = 0; }
-    public int h  { get; set; default = 0; }
-    public string name { get; set; }
-    public string bgcolor { get; set; }
-    public string fgcolor { get; set; }
-    public int clipcolor{ get; set; }
-    public string texture{ get; set; }
-    public string text {get; set;}
+public class DesktopFolder.NoteSettings : Object {
+    public int x  { get;set;default = 0; }
+    public int y  { get;set;default = 0; }
+    public int w  { get;set;default = 0; }
+    public int h  { get;set;default = 0; }
+    public string name { get;set; }
+    public string bgcolor { get;set; }
+    public string fgcolor { get;set; }
+    public int clipcolor { get;set; }
+    public string texture { get;set; }
+    public string text { get;set; }
 
     private File file;
 
-    public NoteSettings(string name){
-        this.x=110;
-        this.y=110;
-        this.bgcolor="df_yellow";
-        this.fgcolor="df_dark";
-        this.texture="";
-        this.clipcolor=Random.int_range(1,6);
-        this.name=name;
-        this.text="Lorem Ipsum";
+    public NoteSettings (string name) {
+        this.x         = 110;
+        this.y         = 110;
+        this.bgcolor   = "df_yellow";
+        this.fgcolor   = "df_dark";
+        this.texture   = "";
+        this.clipcolor = Random.int_range (1, 6);
+        this.name      = name;
+        this.text      = "Lorem Ipsum";
     }
 
 
     /**
-    * @name save
-    * @description persist the changes to the filesystem. The File is the same as the saved initially.
-    */
-    public void save(){
-        this.save_to_file(this.file);
+     * @name save
+     * @description persist the changes to the filesystem. The File is the same as the saved initially.
+     */
+    public void save () {
+        this.save_to_file (this.file);
     }
 
     /**
-    * @name save_to_file
-    * @description persist the changes to the filesystem. The file used is passed to the function, and saved for following saves.
-    * @param file File the file to be saved
-    */
-    public void save_to_file(File file){
-        this.file=file;
-        //string data = Json.gobject_to_data (this, null);
+     * @name save_to_file
+     * @description persist the changes to the filesystem. The file used is passed to the function, and saved for following saves.
+     * @param file File the file to be saved
+     */
+    public void save_to_file (File file) {
+        this.file = file;
+        // string data = Json.gobject_to_data (this, null);
         Json.Node root = Json.gobject_serialize (this);
 
-    	// To string: (see gobject_to_data)
-    	Json.Generator generator = new Json.Generator ();
-    	generator.set_root (root);
-    	string data = generator.to_data (null);
+        // To string: (see gobject_to_data)
+        Json.Generator generator = new Json.Generator ();
+        generator.set_root (root);
+        string data              = generator.to_data (null);
 
         try {
             // an output file in the current working directory
-             if (file.query_exists ()) {
+            if (file.query_exists ()) {
                 file.delete ();
             }
 
@@ -57,7 +57,7 @@ public class DesktopFolder.NoteSettings: Object{
             /*
                 Use BufferedOutputStream to increase write speed:
                 var dos = new DataOutputStream (new BufferedOutputStream.sized (file.create (FileCreateFlags.REPLACE_DESTINATION), 65536));
-            */
+             */
             var dos = new DataOutputStream (file.create (FileCreateFlags.REPLACE_DESTINATION));
             // writing a short string to the stream
             dos.put_string (data);
@@ -68,35 +68,35 @@ public class DesktopFolder.NoteSettings: Object{
     }
 
     /**
-    * @name read_settings
-    * @description read the settings from a file to create a Note Settings object
-    * @param file File the file where the settings are persisted
-    * @param name string the name of the note
-    * @return NoteSettings the NoteSettings created
-    */
-    public static NoteSettings read_settings(File file, string name) {
-        try{
-            string content="";
-            var dis = new DataInputStream (file.read());
+     * @name read_settings
+     * @description read the settings from a file to create a Note Settings object
+     * @param file File the file where the settings are persisted
+     * @param name string the name of the note
+     * @return NoteSettings the NoteSettings created
+     */
+    public static NoteSettings read_settings (File file, string name) {
+        try {
+            string content = "";
+            var    dis     = new DataInputStream (file.read ());
             string line;
             // Read lines until end of file (null) is reached
             while ((line = dis.read_line (null)) != null) {
-                content=content+line;
+                content = content + line;
             }
             NoteSettings existent = Json.gobject_from_data (typeof (NoteSettings), content) as NoteSettings;
-            existent.file=file;
-            existent.name=name;
+            existent.file = file;
+            existent.name = name;
 
-            //regression for classes, now must have a df_ prefix
-            if(existent.bgcolor.length>0 && !existent.bgcolor.has_prefix("df_")){
-                //backward compability
-                existent.bgcolor="df_"+existent.bgcolor;
-                existent.texture="square_paper";
+            // regression for classes, now must have a df_ prefix
+            if (existent.bgcolor.length > 0 && !existent.bgcolor.has_prefix ("df_")) {
+                // backward compability
+                existent.bgcolor = "df_" + existent.bgcolor;
+                existent.texture = "square_paper";
             }
-            if(existent.fgcolor.length>0 && !existent.fgcolor.has_prefix("df_")){
-                //backward compability
-                existent.fgcolor="df_"+existent.fgcolor;
-                existent.texture="square_paper";
+            if (existent.fgcolor.length > 0 && !existent.fgcolor.has_prefix ("df_")) {
+                // backward compability
+                existent.fgcolor = "df_" + existent.fgcolor;
+                existent.texture = "square_paper";
             }
 
             return existent;

--- a/src/settings/PhotoSettings.vala
+++ b/src/settings/PhotoSettings.vala
@@ -1,72 +1,72 @@
-public class DesktopFolder.PhotoSettings: Object{
-    public int x  { get; set; default = 0; }
-    public int y  { get; set; default = 0; }
-    public int w  { get; set; default = 0; }
-    public int h  { get; set; default = 0; }
-    public int fixocolor { get; set; default=0; }
-    public string name { get; set; }
-    public string photo_path { get; set; }
+public class DesktopFolder.PhotoSettings : Object {
+    public int x  { get;set;default = 0; }
+    public int y  { get;set;default = 0; }
+    public int w  { get;set;default = 0; }
+    public int h  { get;set;default = 0; }
+    public int fixocolor { get;set;default = 0; }
+    public string name { get;set; }
+    public string photo_path { get;set; }
 
     private File file;
 
-    public PhotoSettings(string photo_path){
-        this.x=110;
-        this.y=110;
-        this.photo_path=photo_path;
+    public PhotoSettings (string photo_path) {
+        this.x          = 110;
+        this.y          = 110;
+        this.photo_path = photo_path;
         var file = File.new_for_path (photo_path);
-        this.name=file.get_basename();
-        this.fixocolor=Random.int_range(1,6);
+        this.name       = file.get_basename ();
+        this.fixocolor  = Random.int_range (1, 6);
 
-        try{
-            //we calculate an aproximated image size
-            var pixbuf=new Gdk.Pixbuf.from_file(photo_path);
-            this.w=pixbuf.get_width();
-            //max a 30% of the screen
-            Gdk.Screen screen = Gdk.Screen.get_default();
-            int MAX= (screen.get_width()*30)/100;
+        try {
+            // we calculate an aproximated image size
+            var pixbuf = new Gdk.Pixbuf.from_file (photo_path);
+            this.w = pixbuf.get_width ();
+            // max a 30% of the screen
+            Gdk.Screen screen = Gdk.Screen.get_default ();
+            int        MAX    = (screen.get_width () * 30) / 100;
 
-            this.h=pixbuf.get_height();
-            if(this.w>MAX){
-                int diff=this.w-MAX;
-                this.w=MAX;
-                this.h=this.h - diff;
-            }else if (this.h>MAX){
-                int diff=this.h-MAX;
-                this.h=MAX;
-                this.w=this.w - diff;
+            this.h = pixbuf.get_height ();
+            if (this.w > MAX) {
+                int diff = this.w - MAX;
+                this.w = MAX;
+                this.h = this.h - diff;
+            } else if (this.h > MAX)    {
+                int diff = this.h - MAX;
+                this.h = MAX;
+                this.w = this.w - diff;
             }
         } catch (Error e) {
-            //error! ??
+            // error! ??
             stderr.printf ("Error: %s\n", e.message);
         }
     }
 
     /**
-    * @name save
-    * @description persist the changes to the filesystem. The File is the same as the saved initially.
-    */
-    public void save(){
-        this.save_to_file(this.file);
+     * @name save
+     * @description persist the changes to the filesystem. The File is the same as the saved initially.
+     */
+    public void save () {
+        this.save_to_file (this.file);
     }
 
     /**
-    * @name save_to_file
-    * @description persist the changes to the filesystem. The file used is passed to the function, and saved for following saves.
-    * @param file File the file to be saved
-    */
-    public void save_to_file(File file){
-        this.file=file;
-        //string data = Json.gobject_to_data (this, null);
+     * @name save_to_file
+     * @description persist the changes to the filesystem. The file used is passed to the function, and saved for following saves.
+     * @param file File the file to be saved
+     */
+    public void save_to_file (File file) {
+        this.file = file;
+        // string data = Json.gobject_to_data (this, null);
         Json.Node root = Json.gobject_serialize (this);
 
-    	// To string: (see gobject_to_data)
-    	Json.Generator generator = new Json.Generator ();
-    	generator.set_root (root);
-    	string data = generator.to_data (null);
+        // To string: (see gobject_to_data)
+        Json.Generator generator = new Json.Generator ();
+        generator.set_root (root);
+        string data              = generator.to_data (null);
 
         try {
             // an output file in the current working directory
-             if (file.query_exists ()) {
+            if (file.query_exists ()) {
                 file.delete ();
             }
 
@@ -74,7 +74,7 @@ public class DesktopFolder.PhotoSettings: Object{
             /*
                 Use BufferedOutputStream to increase write speed:
                 var dos = new DataOutputStream (new BufferedOutputStream.sized (file.create (FileCreateFlags.REPLACE_DESTINATION), 65536));
-            */
+             */
             var dos = new DataOutputStream (file.create (FileCreateFlags.REPLACE_DESTINATION));
             // writing a short string to the stream
             dos.put_string (data);
@@ -85,24 +85,24 @@ public class DesktopFolder.PhotoSettings: Object{
     }
 
     /**
-    * @name read_settings
-    * @description read the settings from a file to create a Photo Settings object
-    * @param file File the file where the settings are persisted
-    * @param name string the name of the photo
-    * @return PhotoSettings the PhotoSettings created
-    */
-    public static PhotoSettings read_settings(File file, string name) {
-        try{
-            string content="";
-            var dis = new DataInputStream (file.read());
+     * @name read_settings
+     * @description read the settings from a file to create a Photo Settings object
+     * @param file File the file where the settings are persisted
+     * @param name string the name of the photo
+     * @return PhotoSettings the PhotoSettings created
+     */
+    public static PhotoSettings read_settings (File file, string name) {
+        try {
+            string content = "";
+            var    dis     = new DataInputStream (file.read ());
             string line;
             // Read lines until end of file (null) is reached
             while ((line = dis.read_line (null)) != null) {
-                content=content+line;
+                content = content + line;
             }
             PhotoSettings existent = Json.gobject_from_data (typeof (PhotoSettings), content) as PhotoSettings;
-            existent.file=file;
-            existent.name=name;
+            existent.file = file;
+            existent.name = name;
             return existent;
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);

--- a/src/settings/PhotoSettings.vala
+++ b/src/settings/PhotoSettings.vala
@@ -30,7 +30,7 @@ public class DesktopFolder.PhotoSettings : Object {
                 int diff = this.w - MAX;
                 this.w = MAX;
                 this.h = this.h - diff;
-            } else if (this.h > MAX)    {
+            } else if (this.h > MAX) {
                 int diff = this.h - MAX;
                 this.h = MAX;
                 this.w = this.w - diff;

--- a/src/uncrustify-elementary-vala.cfg
+++ b/src/uncrustify-elementary-vala.cfg
@@ -1,0 +1,1647 @@
+# Uncrustify 0.60
+# Rules for vala 
+# Version: 0.5
+
+#
+# General options
+#
+
+# The type of line endings
+newlines                                 = auto     # auto/lf/crlf/cr
+
+# The original size of tabs in the input
+input_tab_size                           = 8        # number
+
+# The size of tabs in the output (only used if align_with_tabs=true)
+output_tab_size                          = 4        # number
+
+# The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
+string_escape_char                       = 92       # number
+
+# Alternate string escape char for Pawn. Only works right before the quote char.
+string_escape_char2                      = 0        # number
+
+# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
+# If true (default), 'assert(x<0 && y>=3)' will be broken.
+# Improvements to template detection may make this option obsolete.
+tok_split_gte                            = false    # false/true
+
+# Control what to do with the UTF-8 BOM (recommend 'remove')
+utf8_bom                                 = ignore   # ignore/add/remove/force
+
+# If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
+utf8_byte                                = false    # false/true
+
+# Force the output encoding to UTF-8
+utf8_force                               = false    # false/true
+
+#
+# Indenting
+#
+
+# The number of columns to indent per level.
+# Usually 2, 3, 4, or 8.
+indent_columns                           = 4        # number
+
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
+# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
+indent_continue                          = 0        # number
+
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs                         = 0        # number
+
+# Comments that are not a brace level are indented with tabs on a tabstop.
+# Requires indent_with_tabs=2. If false, will use spaces.
+indent_cmt_with_tabs                     = false    # false/true
+
+# Whether to indent strings broken by '\' so that they line up
+indent_align_string                      = false    # false/true
+
+# The number of spaces to indent multi-line XML strings.
+# Requires indent_align_string=True
+indent_xml_string                        = 0        # number
+
+# Spaces to indent '{' from level
+indent_brace                             = 0        # number
+
+# Whether braces are indented to the body level
+indent_braces                            = false    # false/true
+
+# Disabled indenting function braces if indent_braces is true
+indent_braces_no_func                    = false    # false/true
+
+# Disabled indenting class braces if indent_braces is true
+indent_braces_no_class                   = false    # false/true
+
+# Disabled indenting struct braces if indent_braces is true
+indent_braces_no_struct                  = false    # false/true
+
+# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+indent_brace_parent                      = false    # false/true
+
+# Whether the 'namespace' body is indented
+indent_namespace                         = true    # false/true
+
+# The number of spaces to indent a namespace block
+indent_namespace_level                   = 0        # number
+
+# If the body of the namespace is longer than this number, it won't be indented.
+# Requires indent_namespace=true. Default=0 (no limit)
+indent_namespace_limit                   = 0        # number
+
+# Whether the 'extern "C"' body is indented
+indent_extern                            = false    # false/true
+
+# Whether the 'class' body is indented
+indent_class                             = true    # false/true
+
+# Whether to indent the stuff after a leading class colon
+indent_class_colon                       = false    # false/true
+# Whether to indent the stuff after a leading class initializer colon
+indent_constr_colon                       = false    # false/true
+
+# Virtual indent from the ':' for member initializers. Default is 2
+indent_ctor_init_leading                 = 2        # number
+
+# Additional indenting for constructor initializer list
+indent_ctor_init                         = 0        # number
+
+# False=treat 'else\nif' as 'else if' for indenting purposes
+# True=indent the 'if' one level
+indent_else_if                           = false    # false/true
+
+# Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
+indent_var_def_blk                       = 0        # number
+
+# Indent continued variable declarations instead of aligning.
+indent_var_def_cont                      = false    # false/true
+
+# True:  force indentation of function definition to start in column 1
+# False: use the default behavior
+indent_func_def_force_col1               = false    # false/true
+
+# True:  indent continued function call parameters one indent level
+# False: align parameters under the open paren
+indent_func_call_param                   = false    # false/true
+
+# Same as indent_func_call_param, but for function defs
+indent_func_def_param                    = false    # false/true
+
+# Same as indent_func_call_param, but for function protos
+indent_func_proto_param                  = false    # false/true
+
+# Same as indent_func_call_param, but for class declarations
+indent_func_class_param                  = false    # false/true
+
+# Same as indent_func_call_param, but for class variable constructors
+indent_func_ctor_var_param               = false    # false/true
+
+# Same as indent_func_call_param, but for templates
+indent_template_param                    = false    # false/true
+
+# Double the indent for indent_func_xxx_param options
+indent_func_param_double                 = false    # false/true
+
+# Indentation column for standalone 'const' function decl/proto qualifier
+indent_func_const                        = 0        # number
+
+# Indentation column for standalone 'throw' function decl/proto qualifier
+indent_func_throw                        = 0        # number
+
+# The number of spaces to indent a continued '->' or '.'
+# Usually set to 0, 1, or indent_columns.
+indent_member                            = 1        # number
+
+# Spaces to indent single line ('//') comments on lines before code
+indent_sing_line_comments                = 0        # number
+
+# If set, will indent trailing single line ('//') comments relative
+# to the code instead of trying to keep the same absolute column
+indent_relative_single_line_comments     = false    # false/true
+
+# Spaces to indent 'case' from 'switch'
+# Usually 0 or indent_columns.
+indent_switch_case                       = 0        # number
+
+# Spaces to shift the 'case' line, without affecting any other lines
+# Usually 0.
+indent_case_shift                        = 0        # number
+
+# Spaces to indent '{' from 'case'.
+# By default, the brace will appear under the 'c' in case.
+# Usually set to 0 or indent_columns.
+indent_case_brace                        = 0        # number
+
+# Whether to indent comments found in first column
+indent_col1_comment                      = false    # false/true
+
+# How to indent goto labels
+#  >0 : absolute column where 1 is the leftmost column
+#  <=0 : subtract from brace indent
+indent_label                             = 1        # number
+
+# Same as indent_label, but for access specifiers that are followed by a colon
+indent_access_spec                       = 1        # number
+
+# Indent the code after an access specifier by one level.
+# If set, this option forces 'indent_access_spec=0'
+indent_access_spec_body                  = false    # false/true
+
+# If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
+indent_paren_nl                          = false    # false/true
+
+# Controls the indent of a close paren after a newline.
+# 0: Indent to body level
+# 1: Align under the open paren
+# 2: Indent to the brace level
+indent_paren_close                       = 2        # number
+
+# Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
+indent_comma_paren                       = false    # false/true
+
+# Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
+indent_bool_paren                        = false    # false/true
+
+# If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
+indent_first_bool_expr                   = false    # false/true
+
+# If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
+indent_square_nl                         = false    # false/true
+
+# Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
+indent_preserve_sql                      = false    # false/true
+
+# Align continued statements at the '='. Default=True
+# If FALSE or the '=' is followed by a newline, the next line is indent one tab.
+indent_align_assign                      = true     # false/true
+
+# Indent OC blocks at brace level instead of usual rules.
+indent_oc_block                          = false    # false/true
+
+# Indent OC blocks in a message relative to the parameter name.
+# 0=use indent_oc_block rules, 1+=spaces to indent
+indent_oc_block_msg                      = 0        # number
+
+# Minimum indent for subsequent parameters
+indent_oc_msg_colon                      = 0        # number
+
+# Objective C
+
+# If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
+# Default is true.
+indent_oc_msg_prioritize_first_colon    = true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
+indent_oc_block_msg_xcode_style         = true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
+indent_oc_block_msg_from_keyword        = true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
+indent_oc_block_msg_from_colon          = true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
+indent_oc_block_msg_from_caret          = true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
+indent_oc_block_msg_from_brace          = true
+
+#
+# Spacing options
+#
+
+# Add or remove space around arithmetic operator '+', '-', '/', '*', etc
+sp_arith                                 = force   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=', '+=', etc
+sp_assign                                = force   # ignore/add/remove/force
+
+# Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
+sp_cpp_lambda_assign                     = force   # ignore/add/remove/force
+
+# Add or remove space after the capture specification in C++11 lambda.
+sp_cpp_lambda_paren                      = force   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=' in a prototype
+sp_assign_default                        = force   # ignore/add/remove/force
+
+# Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_before_assign                         = force   # ignore/add/remove/force
+
+# Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_after_assign                          = force   # ignore/add/remove/force
+
+# Add or remove space around assignment '=' in enum
+sp_enum_assign                           = force   # ignore/add/remove/force
+
+# Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_before_assign                    = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_after_assign                     = force   # ignore/add/remove/force
+
+# Add or remove space around preprocessor '##' concatenation operator. Default=Add
+sp_pp_concat                             = add      # ignore/add/remove/force
+
+# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
+sp_pp_stringify                          = ignore   # ignore/add/remove/force
+
+# Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
+sp_before_pp_stringify                   = ignore   # ignore/add/remove/force
+
+# Add or remove space around boolean operators '&&' and '||'
+sp_bool                                  = force   # ignore/add/remove/force
+
+# Add or remove space around compare operator '<', '>', '==', etc
+sp_compare                               = force   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')'
+sp_inside_paren                          = remove   # ignore/add/remove/force
+
+# Add or remove space between nested parens
+sp_paren_paren                           = remove   # ignore/add/remove/force
+
+# Add or remove space between back-to-back parens: ')(' vs ') ('
+sp_cparen_oparen                          = remove   # ignore/add/remove/force
+# Whether to balance spaces inside nested parens
+sp_balance_nested_parens                 = false    # false/true
+
+# Add or remove space between ')' and '{'
+sp_paren_brace                           = force   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*'
+sp_before_ptr_star                       = force   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*' that isn't followed by a variable name
+# If set to 'ignore', sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star               = force   # ignore/add/remove/force
+
+# Add or remove space between pointer stars '*'
+sp_between_ptr_star                      = force   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a word.
+sp_after_ptr_star                        = force   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by a func proto/def.
+sp_after_ptr_star_func                   = force   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by an open paren (function types).
+sp_ptr_star_paren                        = force   # ignore/add/remove/force
+
+# Add or remove space before a pointer star '*', if followed by a func proto/def.
+sp_before_ptr_star_func                  = force   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&'
+sp_before_byref                          = force   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&' that isn't followed by a variable name
+# If set to 'ignore', sp_before_byref is used instead.
+sp_before_unnamed_byref                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after reference sign '&', if followed by a word.
+sp_after_byref                           = ignore   # ignore/add/remove/force
+
+# Add or remove space after a reference sign '&', if followed by a func proto/def.
+sp_after_byref_func                      = remove   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&', if followed by a func proto/def.
+sp_before_byref_func                     = force   # ignore/add/remove/force
+
+# Add or remove space between type and word. Default=Force
+sp_after_type                            = force    # ignore/add/remove/force
+
+# Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
+sp_before_template_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'template <' vs 'template<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle                        = ignore   # ignore/add/remove/force
+
+# Add or remove space before '<>'
+sp_before_angle                          = remove   # ignore/add/remove/force
+
+# Add or remove space inside '<' and '>'
+sp_inside_angle                          = remove   # ignore/add/remove/force
+
+# Add or remove space after '<>'
+sp_after_angle                           = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '(' as found in 'new List<byte>();'
+sp_angle_paren                           = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and a word as in 'List<byte> m;'
+sp_angle_word                            = force    # ignore/add/remove/force
+
+# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
+sp_angle_shift                           = add      # ignore/add/remove/force
+
+# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
+# sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift                    = false    # false/true
+
+# Add or remove space before '(' of 'if', 'for', 'switch', and 'while'
+sp_before_sparen                         = force      # ignore/add/remove/force
+
+# Add or remove space inside if-condition '(' and ')'
+sp_inside_sparen                         = remove   # ignore/add/remove/force
+
+# Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
+sp_inside_sparen_close                   = ignore   # ignore/add/remove/force
+
+# Add or remove space before if-condition '('. Overrides sp_inside_sparen.
+sp_inside_sparen_open                    = ignore   # ignore/add/remove/force
+
+# Add or remove space after ')' of 'if', 'for', 'switch', and 'while'
+sp_after_sparen                          = force   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while'
+sp_sparen_brace                          = force      # ignore/add/remove/force
+
+# Add or remove space between 'invariant' and '(' in the D language.
+sp_invariant_paren                       = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ')' in 'invariant (C) c' in the D language.
+sp_after_invariant_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space before empty statement ';' on 'if', 'for' and 'while'
+sp_special_semi                          = remove   # ignore/add/remove/force
+
+# Add or remove space before ';'. Default=Remove
+sp_before_semi                           = remove   # ignore/add/remove/force
+
+# Add or remove space before ';' in non-empty 'for' statements
+sp_before_semi_for                       = remove   # ignore/add/remove/force
+
+# Add or remove space before a semicolon of an empty part of a for statement.
+sp_before_semi_for_empty                 = force   # ignore/add/remove/force
+
+# Add or remove space after ';', except when followed by a comment. Default=Add
+sp_after_semi                            = remove      # ignore/add/remove/force
+
+# Add or remove space after ';' in non-empty 'for' statements. Default=Force
+sp_after_semi_for                        = force    # ignore/add/remove/force
+
+# Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
+sp_after_semi_for_empty                  = force   # ignore/add/remove/force
+
+# Add or remove space before '[' (except '[]')
+sp_before_square                         = remove   # ignore/add/remove/force
+
+# Add or remove space before '[]'
+sp_before_squares                        = remove   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'
+sp_inside_square                         = remove   # ignore/add/remove/force
+
+# Add or remove space after ','
+sp_after_comma                           = force   # ignore/add/remove/force
+
+# Add or remove space before ','
+sp_before_comma                          = remove   # ignore/add/remove/force
+
+# Add or remove space between an open paren and comma: '(,' vs '( ,'
+sp_paren_comma                           = force    # ignore/add/remove/force
+
+# Add or remove space before the variadic '...' when preceded by a non-punctuator
+sp_before_ellipsis                       = remove   # ignore/add/remove/force
+
+# Add or remove space after class ':'
+sp_after_class_colon                     = force   # ignore/add/remove/force
+
+# Add or remove space before class ':'
+sp_before_class_colon                    = force   # ignore/add/remove/force
+
+# Add or remove space after class constructor ':'
+sp_after_constr_colon                     = ignore   # ignore/add/remove/force
+
+# Add or remove space before class constructor ':'
+sp_before_constr_colon                    = ignore   # ignore/add/remove/force
+
+# Add or remove space before case ':'. Default=Remove
+sp_before_case_colon                     = remove   # ignore/add/remove/force
+
+# Add or remove space between 'operator' and operator sign
+sp_after_operator                        = force   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open paren, as in 'operator ++('
+sp_after_operator_sym                    = ignore   # ignore/add/remove/force
+
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
+sp_after_cast                            = force   # ignore/add/remove/force
+
+# Add or remove spaces inside cast parens
+sp_inside_paren_cast                     = remove   # ignore/add/remove/force
+
+# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
+sp_cpp_cast_paren                        = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '('
+sp_sizeof_paren                          = force   # ignore/add/remove/force
+
+# Add or remove space after the tag keyword (Pawn)
+sp_after_tag                             = ignore   # ignore/add/remove/force
+
+# Add or remove space inside enum '{' and '}'
+sp_inside_braces_enum                    = force   # ignore/add/remove/force
+
+# Add or remove space inside struct/union '{' force '}'
+sp_inside_braces_struct                  = force   # ignore/add/remove/force
+
+# Add or remove space inside '{' and '}'
+sp_inside_braces                         = force   # ignore/add/remove/force
+
+# Add or remove space inside '{}'
+sp_inside_braces_empty                   = remove   # ignore/add/remove/force
+
+# Add or remove space between return type and function name
+# A minimum of 1 is forced except for pointer return types.
+sp_type_func                             = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function declaration
+sp_func_proto_paren                      = force   # ignore/add/remove/force
+
+# CARL duplicates ERROR ??
+# Add or remove space between function name and '(' on function definition
+sp_func_def_paren                        = force   # ignore/add/remove/force
+
+# Add or remove space inside empty function '()'
+sp_inside_fparens                        = remove   # ignore/add/remove/force
+
+# Add or remove space inside function '(' and ')'
+sp_inside_fparen                         = remove   # ignore/add/remove/force
+
+# Add or remove space inside the first parens in the function type: 'void (*x)(...)'
+sp_inside_tparen                         = remove   # ignore/add/remove/force
+
+# Add or remove between the parens in the function type: 'void (*x)(...)'
+sp_after_tparen_close                    = remove   # ignore/add/remove/force
+
+# Add or remove space between ']' and '(' when part of a function call.
+sp_square_fparen                         = remove   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function
+sp_fparen_brace                          = force   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function calls
+sp_func_call_paren                       = force   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function calls without parameters.
+# If set to 'ignore' (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty                 = force   # ignore/add/remove/force
+
+# Add or remove space between the user function name and '(' on function calls
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor/destructor and the open paren
+sp_func_class_paren                      = force   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '('
+sp_return_paren                          = force   # ignore/add/remove/force
+
+# Add or remove space between '__attribute__' and '('
+sp_attribute_paren                       = force   # ignore/add/remove/force
+
+# Add or remove space between 'defined' and '(' in '#if defined (FOO)'
+sp_defined_paren                         = force   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and '(' in 'throw (something)'
+sp_throw_paren                           = force   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
+sp_after_throw                           = force   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '(' in 'catch (something) { }'
+# If set to ignore, sp_before_sparen is used.
+sp_catch_paren                           = force   # ignore/add/remove/force
+
+# D
+# Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_version_paren                         = ignore   # ignore/add/remove/force
+
+# D
+# Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_scope_paren                           = ignore   # ignore/add/remove/force
+
+# Add or remove space between macro and value
+sp_macro                                 = ignore   # ignore/add/remove/force
+
+# MACRO
+# Add or remove space between macro function ')' and value
+sp_macro_func                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'else' and '{' if on the same line
+sp_else_brace                            = force   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'else' if on the same line
+sp_brace_else                            = force   # ignore/add/remove/force
+
+# Add or remove space between '}' and the name of a typedef on the same line
+sp_brace_typedef                         = force   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '{' if on the same line
+sp_catch_brace                           = force   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'catch' if on the same line
+sp_brace_catch                           = force   # ignore/add/remove/force
+
+# Add or remove space between 'finally' and '{' if on the same line
+sp_finally_brace                         = force   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'finally' if on the same line
+sp_brace_finally                         = force   # ignore/add/remove/force
+
+# Add or remove space between 'try' and '{' if on the same line
+sp_try_brace                             = force   # ignore/add/remove/force
+
+# Add or remove space between get/set and '{' if on the same line
+sp_getset_brace                          = force   # ignore/add/remove/force
+
+# CARL TODO
+
+# Add or remove space between a variable and '{' for C++ uniform initialization
+sp_word_brace                             = ignore
+
+# Add or remove space between a variable and '{' for a namespace
+sp_word_brace_ns                          = add
+
+# C++ 
+# Add or remove space before the '::' operator
+sp_before_dc                             = remove   # ignore/add/remove/force
+
+# C++ 
+# Add or remove space after the '::' operator
+sp_after_dc                              = remove   # ignore/add/remove/force
+
+# Add or remove around the D named array initializer ':' operator
+sp_d_array_colon                         = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '!' (not) operator. Default=Remove
+sp_not                                   = remove   # ignore/add/remove/force
+
+# Add or remove space after the '~' (invert) operator. Default=Remove
+sp_inv                                   = remove   # ignore/add/remove/force
+
+# Add or remove space after the '&' (address-of) operator. Default=Remove
+# This does not affect the spacing after a '&' that is part of a type.
+sp_addr                                  = remove   # ignore/add/remove/force
+
+# Add or remove space around the '.' or '->' operators. Default=Remove
+sp_member                                = remove   # ignore/add/remove/force
+
+# Add or remove space after the '*' (dereference) operator. Default=Remove
+# This does not affect the spacing after a '*' that is part of a type.
+sp_deref                                 = remove   # ignore/add/remove/force
+
+# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
+sp_sign                                  = remove   # ignore/add/remove/force
+
+# Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
+sp_incdec                                = remove   # ignore/add/remove/force
+
+# Add or remove space before a backslash-newline at the end of a line. Default=Add
+sp_before_nl_cont                        = add      # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
+sp_after_oc_scope                        = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after the colon in message specs
+# '-(int) f:(int) x;' vs '-(int) f: (int) x;'
+sp_after_oc_colon                        = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space before the colon in message specs
+# '-(int) f: (int) x;' vs '-(int) f : (int) x;'
+sp_before_oc_colon                       = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'
+sp_after_oc_dict_colon                   = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'
+sp_before_oc_dict_colon                  = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after the colon in message specs
+# '[object setValue:1];' vs '[object setValue: 1];'
+sp_after_send_oc_colon                   = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space before the colon in message specs
+# '[object setValue:1];' vs '[object setValue :1];'
+sp_before_send_oc_colon                  = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after the (type) in message specs
+# '-(int)f: (int) x;' vs '-(int)f: (int)x;'
+sp_after_oc_type                         = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after the first (type) in message specs
+# '-(int) f:(int)x;' vs '-(int)f:(int)x;'
+sp_after_oc_return_type                  = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space between '@selector' and '('
+# '@selector(msgName)' vs '@selector (msgName)'
+# Also applies to @protocol() constructs
+sp_after_oc_at_sel                       = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space between '@selector(x)' and the following word
+# '@selector(foo) a:' vs '@selector(foo)a:'
+sp_after_oc_at_sel_parens                = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space inside '@selector' parens
+# '@selector(foo)' vs '@selector( foo )'
+# Also applies to @protocol() constructs
+sp_inside_oc_at_sel_parens               = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space before a block pointer caret
+# '^int (int arg){...}' vs. ' ^int (int arg){...}'
+sp_before_oc_block_caret                 = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after a block pointer caret
+# '^int (int arg){...}' vs. '^ int (int arg){...}'
+sp_after_oc_block_caret                  = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space between the receiver and selector in a message.
+# '[receiver selector ...]'
+sp_after_oc_msg_receiver                 = ignore   # ignore/add/remove/force
+
+# Obj c
+# Add or remove space after @property.
+sp_after_oc_property                     = ignore   # ignore/add/remove/force
+
+# Add or remove space around the ':' in 'b ? t : f'
+sp_cond_colon                            = force   # ignore/add/remove/force
+# TODO 
+
+# Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_before                      = force 
+#  Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_after                       = force
+# Add or remove space around the '?' in 'b ? t : f'
+sp_cond_question                          = force
+
+# Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_before                   = force
+
+# Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_after                    = force
+
+# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
+sp_cond_ternary_short                     = force
+
+# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
+sp_case_label                            = force   # ignore/add/remove/force
+
+# Control the space around the D '..' operator.
+sp_range                                 = ignore   # ignore/add/remove/force
+
+# Control the spacing after ':' in 'for (TYPE VAR : EXPR)' (Java)
+sp_after_for_colon                        = ignore   # ignore/add/remove/force
+
+# Control the spacing before ':' in 'for (TYPE VAR : EXPR)' (Java)
+sp_before_for_colon                       = ignore   # ignore/add/remove/force
+
+# Control the spacing in 'extern (C)' (D)
+sp_extern_paren                          = ignore   # ignore/add/remove/force
+
+# Control the space after the opening of a C++ comment '// A' vs '//A'
+sp_cmt_cpp_start                         = force    # ignore/add/remove/force
+
+# Controls the spaces between #else or #endif and a trailing comment
+sp_endif_cmt                             = remove   # ignore/add/remove/force
+
+# Controls the spaces after 'new', 'delete', and 'delete[]'
+sp_after_new                             = force   # ignore/add/remove/force
+
+# Controls the spaces before a trailing or embedded comment
+sp_before_tr_emb_cmt                     = force   # ignore/add/remove/force
+
+# Number of spaces before a trailing or embedded comment
+sp_num_before_tr_emb_cmt                 = 0        # number
+
+# Control space between a Java annotation and the open paren.
+sp_annotation_paren                      = ignore   # ignore/add/remove/force
+
+#
+# Code alignment (not left column spaces/tabs)
+#
+
+# Whether to keep non-indenting tabs
+align_keep_tabs                          = false    # false/true
+
+# Whether to use tabs for aligning
+align_with_tabs                          = false    # false/true
+
+# Whether to bump out to the next tab when aligning
+align_on_tabstop                         = false    # false/true
+
+# Whether to left-align numbers
+align_number_left                        = false    # false/true
+
+# TODO DOC
+# Whether to keep whitespace not required for alignment.
+align_keep_extra_space                    = true
+
+# Align variable definitions in prototypes and functions
+align_func_params                        = true    # false/true
+
+# Align parameters in single-line functions that have the same name.
+# The function names must already be aligned with each other.
+align_same_func_call_params              = false    # false/true
+
+# The span for aligning variable definitions (0=don't align)
+align_var_def_span                       = 1        # number
+
+# How to align the star in variable definitions.
+#  0=Part of the type     'void *   foo;'
+#  1=Part of the variable 'void     *foo;'
+#  2=Dangling             'void    *foo;'
+align_var_def_star_style                 = 0        # number
+
+# How to align the '&' in variable definitions.
+#  0=Part of the type
+#  1=Part of the variable
+#  2=Dangling
+align_var_def_amp_style                  = 0        # number
+
+# The threshold for aligning variable definitions (0=no limit)
+align_var_def_thresh                     = 10        # number
+
+# The gap for aligning variable definitions
+align_var_def_gap                        = 0        # number
+
+# Whether to align the colon in struct bit fields
+align_var_def_colon                      = false    # false/true
+
+# Whether to align any attribute after the variable name
+align_var_def_attribute                  = false    # false/true
+
+# Whether to align inline struct/enum/union variable definitions
+align_var_def_inline                     = false    # false/true
+
+# The span for aligning on '=' in assignments (0=don't align)
+align_assign_span                        = 2        # number
+
+# The threshold for aligning on '=' in assignments (0=no limit)
+align_assign_thresh                      = 20        # number
+
+# The span for aligning on '=' in enums (0=don't align)
+align_enum_equ_span                      = 0        # number
+
+# The threshold for aligning on '=' in enums (0=no limit)
+align_enum_equ_thresh                    = 0        # number
+
+# The span for aligning struct/union (0=don't align)
+align_var_struct_span                    = 0        # number
+
+# The threshold for aligning struct/union member definitions (0=no limit)
+align_var_struct_thresh                  = 0        # number
+
+# The gap for aligning struct/union member definitions
+align_var_struct_gap                     = 0        # number
+
+# The span for aligning struct initializer values (0=don't align)
+align_struct_init_span                   = 0        # number
+
+# The minimum space between the type and the synonym of a typedef
+align_typedef_gap                        = 0        # number
+
+# The span for aligning single-line typedefs (0=don't align)
+align_typedef_span                       = 0        # number
+
+# How to align typedef'd functions with other typedefs
+# 0: Don't mix them at all
+# 1: align the open paren with the types
+# 2: align the function type name with the other type names
+align_typedef_func                       = 0        # number
+
+# Controls the positioning of the '*' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '*'
+# 1: The '*' is part of type name: typedef int  *pint;
+# 2: The '*' is part of the type, but dangling: typedef int *pint;
+align_typedef_star_style                 = 0        # number
+
+# Controls the positioning of the '&' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '&'
+# 1: The '&' is part of type name: typedef int  &pint;
+# 2: The '&' is part of the type, but dangling: typedef int &pint;
+align_typedef_amp_style                  = 0        # number
+
+# The span for aligning comments that end lines (0=don't align)
+align_right_cmt_span                     = 0        # number
+
+# If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
+align_right_cmt_mix                      = false    # false/true
+
+# If a trailing comment is more than this number of columns away from the text it follows,
+# it will qualify for being aligned. This has to be > 0 to do anything.
+align_right_cmt_gap                      = 0        # number
+
+# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
+align_right_cmt_at_col                   = 0        # number
+
+# The span for aligning function prototypes (0=don't align)
+align_func_proto_span                    = 0        # number
+
+# Minimum gap between the return type and the function name.
+align_func_proto_gap                     = 0        # number
+
+# Align function protos on the 'operator' keyword instead of what follows
+align_on_operator                        = false    # false/true
+
+# Whether to mix aligning prototype and variable declarations.
+# If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
+align_mix_var_proto                      = false    # false/true
+
+# Align single-line functions with function prototypes, uses align_func_proto_span
+align_single_line_func                   = false    # false/true
+
+# Aligning the open brace of single-line functions.
+# Requires align_single_line_func=true, uses align_func_proto_span
+align_single_line_brace                  = false    # false/true
+
+# Gap for align_single_line_brace.
+align_single_line_brace_gap              = 0        # number
+
+# The span for aligning ObjC msg spec (0=don't align)
+align_oc_msg_spec_span                   = 0        # number
+
+# Whether to align macros wrapped with a backslash and a newline.
+# This will not work right if the macro contains a multi-line comment.
+align_nl_cont                            = false    # false/true
+
+# # Align macro functions and variables together
+align_pp_define_together                 = false    # false/true
+
+# The minimum space between label and value of a preprocessor define
+align_pp_define_gap                      = 0        # number
+
+# The span for aligning on '#define' bodies (0=don't align)
+align_pp_define_span                     = 0        # number
+
+# Align lines that start with '<<' with previous '<<'. Default=true
+align_left_shift                         = true     # false/true
+
+# Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
+align_oc_msg_colon_span                  = 0        # number
+
+# If true, always align with the first parameter, even if it is too short.
+align_oc_msg_colon_first                 = false    # false/true
+
+# Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
+align_oc_decl_colon                      = false    # false/true
+
+#
+# Newline adding and removing options
+#
+
+# Whether to collapse empty blocks between '{' and '}'
+nl_collapse_empty_body                   = false    # false/true
+
+# Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
+nl_assign_leave_one_liners               = true    # false/true
+
+# Don't split one-line braced statements inside a class xx { } body
+nl_class_leave_one_liners                = false    # false/true
+
+# Don't split one-line enums: 'enum foo { BAR = 15 };'
+nl_enum_leave_one_liners                 = false    # false/true
+
+# Don't split one-line get or set functions
+nl_getset_leave_one_liners               = false    # false/true
+
+# Don't split one-line function definitions - 'int foo() { return 0; }'
+nl_func_leave_one_liners                 = false    # false/true
+
+# Don't split one-line if/else statements - 'if(a) b++;'
+nl_if_leave_one_liners                   = false    # false/true
+
+# Don't split one-line OC messages
+nl_oc_msg_leave_one_liner                = false    # false/true
+
+# Add or remove newlines at the start of the file
+nl_start_of_file                         = ignore   # ignore/add/remove/force
+
+# The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
+nl_start_of_file_min                     = 0        # number
+
+# Add or remove newline at the end of the file
+nl_end_of_file                           = ignore   # ignore/add/remove/force
+
+# The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
+nl_end_of_file_min                       = 0        # number
+
+# Add or remove newline between '=' and '{'
+nl_assign_brace                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '=' and '[' (D only)
+nl_assign_square                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
+nl_after_square_assign                   = ignore   # ignore/add/remove/force
+
+# The number of blank lines after a block of variable definitions at the top of a function body
+# 0 = No change (default)
+nl_func_var_def_blk                      = 0        # number
+
+# The number of newlines before a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_start                     = 0        # number
+
+# The number of newlines after a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_end                       = 0        # number
+
+# The maximum consecutive newlines within a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_in                        = 0        # number
+
+# The number of newlines before a block of variable definitions not at the top of a function body
+# 0 = No change (default)
+nl_var_def_blk_start                     = 0        # number
+
+# The number of newlines after a block of variable definitions not at the top of a function body
+# 0 = No change (default)
+nl_var_def_blk_end                       = 0        # number
+
+# The maximum consecutive newlines within a block of variable definitions
+# 0 = No change (default)
+nl_var_def_blk_in                        = 0        # number
+
+# Add or remove newline between a function call's ')' and '{', as in:
+# list_for_each(item, &list) { }
+nl_fcall_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and '{'
+nl_enum_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'struct and '{'
+nl_struct_brace                          = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'union' and '{'
+nl_union_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'if' and '{'
+nl_if_brace                              = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'else'
+nl_brace_else                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'else if' and '{'
+# If set to ignore, nl_if_brace is used instead
+nl_elseif_brace                          = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and '{'
+nl_else_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and 'if'
+nl_else_if                               = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'finally'
+nl_brace_finally                         = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'finally' and '{'
+nl_finally_brace                         = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'try' and '{'
+nl_try_brace                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between get/set and '{'
+nl_getset_brace                          = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'for' and '{'
+nl_for_brace                             = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'catch' and '{'
+nl_catch_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'
+nl_brace_catch                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ']'
+nl_brace_square                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ')' in a function invocation
+nl_brace_fparen                           = remove   # ignore/add/remove/force
+# Add or remove newline between 'while' and '{'
+nl_while_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'scope (x)' and '{' (D)
+nl_scope_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'unittest' and '{' (D)
+nl_unittest_brace                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'version (x)' and '{' (D)
+nl_version_brace                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'using' and '{'
+nl_using_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between two open or close braces.
+# Due to general newline/brace handling, REMOVE may not work.
+nl_brace_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'do' and '{'
+nl_do_brace                              = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'while' of 'do' statement
+nl_brace_while                           = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'switch' and '{'
+nl_switch_brace                          = remove   # ignore/add/remove/force
+
+# Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch, and nl_catch_brace.
+nl_multi_line_cond                       = false    # false/true
+
+# Force a newline in a define after the macro name for multi-line defines.
+nl_multi_line_define                     = false    # false/true
+
+# Whether to put a newline before 'case' statement
+nl_before_case                           = false    # false/true
+
+# Add or remove newline between ')' and 'throw'
+nl_before_throw                          = remove   # ignore/add/remove/force
+
+# Whether to put a newline after 'case' statement
+nl_after_case                            = false    # false/true
+
+# Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
+nl_case_colon_brace                      = ignore   # ignore/add/remove/force
+
+# Newline between namespace and {
+nl_namespace_brace                       = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'template<>' and whatever follows.
+nl_template_class                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'class' and '{'
+nl_class_brace                           = remove   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the class base list
+nl_class_init_args                        = remove   # ignore/add/remove/force
+# Add or remove newline after each ',' in the constructor member initialization
+nl_class_init_args                       = remove   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a function definition
+nl_func_type_name                        = remove   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name inside a class {}
+# Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
+nl_func_type_name_class                  = remove   # ignore/add/remove/force
+
+# Add or remove newline between function scope and name in a definition
+# Controls the newline after '::' in 'void A::f() { }'
+nl_func_scope_name                       = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a prototype
+nl_func_proto_type_name                  = remove   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '('
+nl_func_paren                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the definition
+nl_func_def_paren                        = remove   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function declaration
+nl_func_decl_start                       = remove   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function definition
+nl_func_def_start                        = remove   # ignore/add/remove/force
+
+# Overrides nl_func_decl_start when there is only one parameter.
+nl_func_decl_start_single                = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_start when there is only one parameter.
+nl_func_def_start_single                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function declaration
+nl_func_decl_args                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function definition
+nl_func_def_args                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function declaration
+nl_func_decl_end                         = remove   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function definition
+nl_func_def_end                          = remove   # ignore/add/remove/force
+
+# Overrides nl_func_decl_end when there is only one parameter.
+nl_func_decl_end_single                  = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_end when there is only one parameter.
+nl_func_def_end_single                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function declaration.
+nl_func_decl_empty                       = remove   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function definition.
+nl_func_def_empty                        = remove   # ignore/add/remove/force
+
+# Whether to put each OC message parameter on a separate line
+# See nl_oc_msg_leave_one_liner
+nl_oc_msg_args                           = false    # false/true
+
+# Add or remove newline between function signature and '{'
+nl_fdef_brace                            = remove   # ignore/add/remove/force
+
+# Add or remove newline between C++11 lambda signature and '{'
+nl_cpp_ldef_brace                         = ignore   # ignore/add/remove/force
+
+# Add or remove a newline between the return keyword and return expression.
+nl_return_expr                           = remove   # ignore/add/remove/force
+
+# Whether to put a newline after semicolons, except in 'for' statements
+nl_after_semicolon                       = false    # false/true
+
+# CARL ??
+# Whether to put a newline after brace open.
+# This also adds a newline before the matching brace close.
+nl_after_brace_open                      = false    # false/true
+
+# If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
+# placed between the open brace and a trailing single-line comment.
+nl_after_brace_open_cmt                  = false    # false/true
+
+# Whether to put a newline after a virtual brace open with a non-empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open                     = false    # false/true
+
+# Whether to put a newline after a virtual brace open with an empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open_empty               = false    # false/true
+
+# Whether to put a newline after a brace close.
+# Does not apply if followed by a necessary ';'.
+nl_after_brace_close                     = false    # false/true
+
+# Whether to put a newline after a virtual brace close.
+# Would add a newline before return in: 'if (foo) a++; return;'
+nl_after_vbrace_close                    = false    # false/true
+
+# Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
+# Affects enums, unions, and structures. If set to ignore, uses nl_after_brace_close
+nl_brace_struct_var                      = ignore   # ignore/add/remove/force
+
+# Whether to alter newlines in '#define' macros
+nl_define_macro                          = false    # false/true
+
+# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'
+nl_squeeze_ifdef                         = false    # false/true
+
+# Add or remove blank line before 'if'
+nl_before_if                             = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'if' statement
+nl_after_if                              = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'for'
+nl_before_for                            = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'for' statement
+nl_after_for                             = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'while'
+nl_before_while                          = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'while' statement
+nl_after_while                           = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'switch'
+nl_before_switch                         = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'switch' statement
+nl_after_switch                          = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'do'
+nl_before_do                             = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'do/while' statement
+nl_after_do                              = ignore   # ignore/add/remove/force
+
+# Whether to double-space commented-entries in struct/enum
+nl_ds_struct_enum_cmt                    = false    # false/true
+
+# Whether to double-space before the close brace of a struct/union/enum
+# (lower priority than 'eat_blanks_before_close_brace')
+nl_ds_struct_enum_close_brace            = false    # false/true
+
+# Add or remove a newline around a class colon.
+# Related to pos_class_colon, nl_class_init_args, and pos_comma.
+nl_class_colon                           = ignore   # ignore/add/remove/force
+
+# Add or remove a newline around a class constructor colon.
+# Related to pos_constr_colon, nl_constr_init_args, and pos_constr_comma.
+nl_constr_colon                           = ignore   # ignore/add/remove/force
+
+
+# Change simple unbraced if statements into a one-liner
+# 'if(b)\n i++;' => 'if(b) i++;'
+nl_create_if_one_liner                   = false    # false/true
+
+# Change simple unbraced for statements into a one-liner
+# 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
+nl_create_for_one_liner                  = false    # false/true
+
+# Change simple unbraced while statements into a one-liner
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
+nl_create_while_one_liner                = false    # false/true
+
+#
+# Positioning options
+#
+
+# The position of arithmetic operators in wrapped expressions
+pos_arith                                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of assignment in wrapped expressions.
+# Do not affect '=' followed by '{'
+pos_assign                               = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of boolean operators in wrapped expressions
+pos_bool                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of comparison operators in wrapped expressions
+pos_compare                              = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of conditional (b ? t : f) operators in wrapped expressions
+pos_conditional                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in wrapped expressions
+pos_comma                                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in the class base list
+pos_class_comma                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in the constructor initialization list
+pos_constr_comma                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of colons between class and base class list
+pos_class_colon                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of colons between constructor and member initialization
+pos_constr_colon                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+#
+# Line Splitting options
+#
+
+# Try to limit code width to N number of columns
+code_width                               = 0        # number
+
+# Whether to fully split long 'for' statements at semi-colons
+ls_for_split_full                        = false    # false/true
+
+# Whether to fully split long function protos/calls at commas
+ls_func_split_full                       = false    # false/true
+
+# Whether to split lines as close to code_width as possible and ignore some groupings
+ls_code_width                            = false    # false/true
+
+#
+# Blank line options
+#
+
+# The maximum consecutive newlines
+nl_max                                   = 0        # number
+
+# The number of newlines after a function prototype, if followed by another function prototype
+nl_after_func_proto                      = 0        # number
+
+# The number of newlines after a function prototype, if not followed by another function prototype
+nl_after_func_proto_group                = 2        # number
+
+# The number of newlines after '}' of a multi-line function body
+nl_after_func_body                       = 2        # number
+
+# The number of newlines after '}' of a multi-line function body in a class declaration
+nl_after_func_body_class                 = 2        # number
+
+# The number of newlines after '}' of a single line function body
+nl_after_func_body_one_liner             = 0        # number
+
+# The minimum number of newlines before a multi-line comment.
+# Doesn't apply if after a brace open or another multi-line comment.
+nl_before_block_comment                  = 0        # number
+
+# The minimum number of newlines before a single-line C comment.
+# Doesn't apply if after a brace open or other single-line C comments.
+nl_before_c_comment                      = 0        # number
+
+# The minimum number of newlines before a CPP comment.
+# Doesn't apply if after a brace open or other CPP comments.
+nl_before_cpp_comment                    = 0        # number
+
+# Whether to force a newline after a multi-line comment.
+nl_after_multiline_comment               = false    # false/true
+
+# The number of newlines after '}' or ';' of a struct/enum/union definition
+nl_after_struct                          = 0        # number
+
+# The number of newlines after '}' or ';' of a class definition
+nl_after_class                           = 0        # number
+
+# The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# Will not change the newline count if after a brace open.
+# 0 = No change.
+nl_before_access_spec                    = 0        # number
+
+# The number of newlines after a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# 0 = No change.
+nl_after_access_spec                     = 0        # number
+
+# The number of newlines between a function def and the function comment.
+# 0 = No change.
+nl_comment_func_def                      = 0        # number
+
+# The number of newlines after a try-catch-finally block that isn't followed by a brace close.
+# 0 = No change.
+nl_after_try_catch_finally               = 0        # number
+
+# The number of newlines before and after a property, indexer or event decl.
+# 0 = No change.
+nl_around_cs_property                    = 0        # number
+
+# The number of newlines between the get/set/add/remove handlers in C#.
+# 0 = No change.
+nl_between_get_set                       = 0        # number
+
+# Add or remove newline between C# property and the '{'
+nl_property_brace                        = ignore   # ignore/add/remove/force
+
+# Whether to remove blank lines after '{'
+eat_blanks_after_open_brace              = false    # false/true
+
+# Whether to remove blank lines before '}'
+eat_blanks_before_close_brace            = false    # false/true
+
+# How aggressively to remove extra newlines not in preproc.
+# 0: No change
+# 1: Remove most newlines not handled by other config
+# 2: Remove all newlines and reformat completely by config
+nl_remove_extra_newlines                 = 0        # number
+
+# Whether to put a blank line before 'return' statements, unless after an open brace.
+nl_before_return                         = false    # false/true
+
+# Whether to put a blank line after 'return' statements, unless followed by a close brace.
+nl_after_return                          = false    # false/true
+
+# Whether to put a newline after a Java annotation statement.
+# Only affects annotations that are after a newline.
+nl_after_annotation                      = ignore   # ignore/add/remove/force
+
+# Controls the newline between two annotations.
+nl_between_annotation                    = ignore   # ignore/add/remove/force
+
+#
+# Code modifying options (non-whitespace)
+#
+
+# Add or remove braces on single-line 'do' statement
+mod_full_brace_do                        = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'for' statement
+mod_full_brace_for                       = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line function definitions. (Pawn)
+mod_full_brace_function                  = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
+mod_full_brace_if                        = ignore   # ignore/add/remove/force
+
+# Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
+# If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
+mod_full_brace_if_chain                  = false    # false/true
+
+# Don't remove braces around statements that span N newlines
+mod_full_brace_nl                        = 0        # number
+
+# Add or remove braces on single-line 'while' statement
+mod_full_brace_while                     = ignore   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'using ()' statement
+mod_full_brace_using                     = ignore   # ignore/add/remove/force
+
+# Add or remove unnecessary paren on 'return' statement
+mod_paren_on_return                      = ignore   # ignore/add/remove/force
+
+# Whether to change optional semicolons to real semicolons
+mod_pawn_semicolon                       = false    # false/true
+
+# Add parens on 'while' and 'if' statement around bools
+mod_full_paren_if_bool                   = false    # false/true
+
+# Whether to remove superfluous semicolons
+mod_remove_extra_semicolon               = false    # false/true
+
+# If a function body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_function_closebrace_comment = 0        # number
+
+# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 0        # number
+# If a switch body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_switch_closebrace_comment   = 0        # number
+
+# If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
+# the #endif, a comment will be added.
+mod_add_long_ifdef_endif_comment         = 0        # number
+
+# If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
+# the #else, a comment will be added.
+mod_add_long_ifdef_else_comment          = 0        # number
+
+# If TRUE, will sort consecutive single-line 'import' statements [Java, D]
+mod_sort_import                          = false    # false/true
+
+# If TRUE, will sort consecutive single-line 'using' statements [C#]
+mod_sort_using                           = false    # false/true
+
+# If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
+# This is generally a bad idea, as it may break your code.
+mod_sort_include                         = false    # false/true
+
+# If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
+mod_move_case_break                      = false    # false/true
+
+# Will add or remove the braces around a fully braced case statement.
+# Will only remove the braces if there are no variable declarations in the block.
+mod_case_brace                           = ignore   # ignore/add/remove/force
+
+# If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
+mod_remove_empty_return                  = false    # false/true
+
+#
+# Comment modifications
+#
+
+# Try to wrap comments at cmt_width columns
+cmt_width                                = 0        # number
+
+# Set the comment reflow mode (default: 0)
+# 0: no reflowing (apart from the line wrapping due to cmt_width)
+# 1: no touching at all
+# 2: full reflow
+cmt_reflow_mode                          = 0        # number
+
+# If false, disable all multi-line comment changes, including cmt_width. keyword substitution, and leading chars.
+# Default is true.
+cmt_indent_multi                         = true     # false/true
+
+# Whether to group c-comments that look like they are in a block
+cmt_c_group                              = false    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined c-comment
+cmt_c_nl_start                           = false    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined c-comment
+cmt_c_nl_end                             = false    # false/true
+
+# Whether to group cpp-comments that look like they are in a block
+cmt_cpp_group                            = false    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined cpp-comment
+cmt_cpp_nl_start                         = false    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined cpp-comment
+cmt_cpp_nl_end                           = false    # false/true
+
+# Whether to change cpp-comments into c-comments
+cmt_cpp_to_c                             = false    # false/true
+
+# Whether to put a star on subsequent comment lines
+cmt_star_cont                            = false    # false/true
+
+# The number of spaces to insert at the start of subsequent comment lines
+cmt_sp_before_star_cont                  = 0        # number
+
+# The number of spaces to insert after the star on subsequent comment lines
+cmt_sp_after_star_cont                   = 0        # number
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# the comment are the same length. Default=True
+cmt_multi_check_last                     = true     # false/true
+
+# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_header                   = ""         # string
+
+# The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_footer                   = ""         # string
+
+# The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
+# Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
+cmt_insert_func_header                   = ""         # string
+
+# The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
+# Will substitute $(class) with the class name.
+cmt_insert_class_header                  = ""         # string
+
+# The filename that contains text to insert before a Obj-C message specification if the method isn't preceeded with a C/C++ comment.
+# Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+cmt_insert_oc_msg_header                 = ""         # string
+
+# If a preprocessor is encountered when stepping backwards from a function name, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+cmt_insert_before_preproc                = false    # false/true
+
+#
+# Preprocessor options
+#
+
+# Control indent of preprocessors inside #if blocks at brace level 0
+pp_indent                                = ignore   # ignore/add/remove/force
+
+# Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
+pp_indent_at_level                       = false    # false/true
+
+# If pp_indent_at_level=false, specifies the number of columns to indent per level. Default=1.
+pp_indent_count                          = 1        # number
+
+# Add or remove space after # based on pp_level of #if blocks
+pp_space                                 = ignore   # ignore/add/remove/force
+
+# Sets the number of spaces added with pp_space
+pp_space_count                           = 0        # number
+
+# The indent for #region and #endregion in C# and '#pragma region' in C/C++
+pp_indent_region                         = 0        # number
+
+# Whether to indent the code between #region and #endregion
+pp_region_indent_code                    = false    # false/true
+
+# If pp_indent_at_level=true, sets the indent for #if, #else, and #endif when not at file-level
+pp_indent_if                             = 0        # number
+
+# Control whether to indent the code between #if, #else and #endif when not at file-level
+pp_if_indent_code                        = false    # false/true
+
+# Whether to indent '#define' at the brace level (true) or from column 1 (false)
+pp_define_at_level                       = false    # false/true
+

--- a/src/utils/RenameDialog.vala
+++ b/src/utils/RenameDialog.vala
@@ -1,30 +1,30 @@
 public class RenameDialog : Gtk.Dialog {
-	private Gtk.Entry entry;
+    private Gtk.Entry entry;
 
-    public signal void on_rename(string new_name);
-    public signal void on_cancel();
+    public signal void on_rename (string new_name);
+    public signal void on_cancel ();
 
-	public RenameDialog (Gtk.Window parent, string title, string label_message, string entry_text) {
-        if(parent!=null){
-            this.set_transient_for(parent);
+    public RenameDialog (Gtk.Window parent, string title, string label_message, string entry_text) {
+        if (parent != null) {
+            this.set_transient_for (parent);
         }
-		this.title = title;
-		this.border_width = 5;
-		set_default_size (350, 100);
+        this.title        = title;
+        this.border_width = 5;
+        set_default_size (350, 100);
         this.get_style_context ().add_class ("df_dialog");
-        this.set_decorated(true);
+        this.set_decorated (true);
 
-		create_widgets (label_message, entry_text);
-		connect_signals ();
-	}
+        create_widgets (label_message, entry_text);
+        connect_signals ();
+    }
 
-	private void create_widgets (string label_message, string entry_text) {
+    private void create_widgets (string label_message, string entry_text) {
 
-        var description=new Gtk.Label (label_message);
-        description.halign=Gtk.Align.START;
-        this.entry = new Gtk.Entry();
-        this.entry.activate.connect(()=>{
-            this.response(Gtk.ResponseType.OK);
+        var description = new Gtk.Label (label_message);
+        description.halign = Gtk.Align.START;
+        this.entry         = new Gtk.Entry ();
+        this.entry.activate.connect (() => {
+            this.response (Gtk.ResponseType.OK);
         });
         this.entry.set_text (entry_text);
 
@@ -34,8 +34,8 @@ public class RenameDialog : Gtk.Dialog {
         hbox.pack_start (entry, true, true, 0);
 
         var grid = new Gtk.Grid ();
-        grid.margin=10;
-        grid.attach(hbox,0,0,1,1);
+        grid.margin = 10;
+        grid.attach (hbox, 0, 0, 1, 1);
 
         Gtk.Box content = this.get_content_area () as Gtk.Box;
         content.pack_start (grid, false, true, 0);
@@ -44,23 +44,23 @@ public class RenameDialog : Gtk.Dialog {
         // Add buttons to button area at the bottom
         add_button (DesktopFolder.Lang.DIALOG_OK, Gtk.ResponseType.OK);
         add_button (DesktopFolder.Lang.DIALOG_CANCEL, Gtk.ResponseType.CANCEL);
-	}
+    }
 
-	private void connect_signals () {
-		this.response.connect (on_response);
-	}
+    private void connect_signals () {
+        this.response.connect (on_response);
+    }
 
-	private void on_response (Gtk.Dialog source, int response_id) {
-		switch (response_id) {
-    		case Gtk.ResponseType.OK:
-    			this.on_rename(this.entry.get_text());
-                this.destroy ();
-    			break;
-            case Gtk.ResponseType.CANCEL:
-                this.on_cancel();
-                this.destroy ();
-                break;
+    private void on_response (Gtk.Dialog source, int response_id) {
+        switch (response_id) {
+        case Gtk.ResponseType.OK:
+            this.on_rename (this.entry.get_text ());
+            this.destroy ();
+            break;
+        case Gtk.ResponseType.CANCEL:
+            this.on_cancel ();
+            this.destroy ();
+            break;
         }
-	}
+    }
 
 }

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -15,66 +15,65 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
-namespace DesktopFolder.Util
-{
-
-	/**
-	 * Display a simple error message.
-	 * @param title The title of the dialog.
-	 * @param message The error message.
-	 */
-	public void show_error_dialog (string? title, string message){
-		var dialog = new Gtk.MessageDialog(null, 0,
-		                                   Gtk.MessageType.ERROR,
-		                                   Gtk.ButtonsType.CLOSE,
-		                                   "%s", message);
-		dialog.title = title;
-		dialog.border_width = 5;
-		dialog.run();
-		dialog.destroy();
-	}
+namespace DesktopFolder.Util {
 
     /**
-    * @name FileOperationAction
-    * @description delegate function to inform about the copy being operated
-    * @param {GLib.File} file the file being operated
-    */
-    public delegate void FileOperationAction(GLib.File file);
+     * Display a simple error message.
+     * @param title The title of the dialog.
+     * @param message The error message.
+     */
+    public void show_error_dialog (string ? title, string message) {
+        var dialog = new Gtk.MessageDialog (null, 0,
+                                            Gtk.MessageType.ERROR,
+                                            Gtk.ButtonsType.CLOSE,
+                                            "%s", message);
+        dialog.title        = title;
+        dialog.border_width = 5;
+        dialog.run ();
+        dialog.destroy ();
+    }
 
     /**
-    * @name copy_recursive
-    * @description this function copy recursively from a GLib.File to a GLib.File
-    * @param {GLib.File} src the origin file
-    * @param {GLib.File} src the destination file
-    * @param {GLib.FileCopyFlags} flags the set of flags for the copy operation (NONE by default)
-    * @param {GLib.Cancellable} cancellable object to allow cancel the operation
-    * @param {FileOperationAction} listener the listener to get the current operation
-    * @return bool true->if everything was OK
-    */
+     * @name FileOperationAction
+     * @description delegate function to inform about the copy being operated
+     * @param {GLib.File} file the file being operated
+     */
+    public delegate void FileOperationAction (GLib.File file);
+
+    /**
+     * @name copy_recursive
+     * @description this function copy recursively from a GLib.File to a GLib.File
+     * @param {GLib.File} src the origin file
+     * @param {GLib.File} src the destination file
+     * @param {GLib.FileCopyFlags} flags the set of flags for the copy operation (NONE by default)
+     * @param {GLib.Cancellable} cancellable object to allow cancel the operation
+     * @param {FileOperationAction} listener the listener to get the current operation
+     * @return bool true->if everything was OK
+     */
     public bool copy_recursive (GLib.File src, GLib.File dest, GLib.FileCopyFlags flags = GLib.FileCopyFlags.NONE,
-        GLib.Cancellable? cancellable = null,FileOperationAction? listener=null ) throws GLib.Error {
+                                GLib.Cancellable ? cancellable = null, FileOperationAction ? listener = null) throws GLib.Error {
         GLib.FileType src_type = src.query_file_type (GLib.FileQueryInfoFlags.NONE, cancellable);
-        if ( src_type == GLib.FileType.DIRECTORY ) {
+        if (src_type == GLib.FileType.DIRECTORY) {
             dest.make_directory (cancellable);
             src.copy_attributes (dest, flags, cancellable);
 
-            string src_path = src.get_path ();
-            string dest_path = dest.get_path ();
+            string src_path                = src.get_path ();
+            string dest_path               = dest.get_path ();
             GLib.FileEnumerator enumerator = src.enumerate_children (GLib.FileAttribute.STANDARD_NAME, GLib.FileQueryInfoFlags.NONE, cancellable);
-            for ( GLib.FileInfo? info = enumerator.next_file (cancellable) ; info != null ; info = enumerator.next_file (cancellable) ) {
+            for (GLib.FileInfo ? info = enumerator.next_file (cancellable) ; info != null ; info = enumerator.next_file (cancellable)) {
                 copy_recursive (
                     GLib.File.new_for_path (GLib.Path.build_filename (src_path, info.get_name ())),
                     GLib.File.new_for_path (GLib.Path.build_filename (dest_path, info.get_name ())),
                     flags,
                     cancellable, listener);
             }
-        } else if ( src_type == GLib.FileType.REGULAR ) {
-            if(listener!=null){
-                listener(dest);
-            }else{
-                debug("copying %s",dest.get_basename());
+        } else if (src_type == GLib.FileType.REGULAR) {
+            if (listener != null) {
+                listener (dest);
+            } else {
+                debug ("copying %s", dest.get_basename ());
             }
             src.copy (dest, flags, cancellable);
         }
@@ -82,258 +81,255 @@ namespace DesktopFolder.Util
         return true;
     }
 
-	/**
-	 * Returns the parent window of the specified widget.
-	 */
-	public Gtk.Window widget_window(Gtk.Widget widg)
-	{
-		while (widg.get_parent() != null) widg = widg.get_parent();
-		return widg as Gtk.Window;
-	}
+    /**
+     * Returns the parent window of the specified widget.
+     */
+    public Gtk.Window widget_window (Gtk.Widget widg) {
+        while (widg.get_parent () != null) widg = widg.get_parent ();
+        return widg as Gtk.Window;
+    }
 
-	/**
-	 * Returns an absolute path for the given path.
-	 */
-	public static string absolute_path(string path)
-	{
-		var file = GLib.File.new_for_path(path);
-		return file.resolve_relative_path(".").get_path();
-	}
+    /**
+     * Returns an absolute path for the given path.
+     */
+    public static string absolute_path (string path) {
+        var file = GLib.File.new_for_path (path);
+        return file.resolve_relative_path (".").get_path ();
+    }
 
-	/**
-	 * Converts the given angle from degrees to radians.
-	 *
-	 * @param deg Angle in radians
-	 * @return Angle in degrees
-	 */
-	public static double deg_to_rad (double deg) {
-		return (deg * Math.PI / 180f);
-	}
+    /**
+     * Converts the given angle from degrees to radians.
+     *
+     * @param deg Angle in radians
+     * @return Angle in degrees
+     */
+    public static double deg_to_rad (double deg) {
+        return (deg * Math.PI / 180f);
+    }
 
-	/**
-	 * Converts the given angle from radians to degrees.
-	 *
-	 * @param rad Angle in degrees
-	 * @return Angle in radians
-	 */
-	public static double rad_to_deg (double rad) {
-		return (rad / Math.PI * 180f);
-	}
+    /**
+     * Converts the given angle from radians to degrees.
+     *
+     * @param rad Angle in degrees
+     * @return Angle in radians
+     */
+    public static double rad_to_deg (double rad) {
+        return (rad / Math.PI * 180f);
+    }
 
-	/**
-	* @name create_new_photo
-	* @param {Gtk.Window} window the parent window to show the dialog
-	* @description show a dialog to create a new photo
-	*/
-	public static void create_new_photo(Gtk.Window window){
-		Gtk.FileChooserDialog chooser = new Gtk.FileChooserDialog (
-				DesktopFolder.Lang.PHOTO_SELECT_PHOTO_MESSAGE, window,
-				Gtk.FileChooserAction.OPEN,
-				DesktopFolder.Lang.DIALOG_CANCEL,
-				Gtk.ResponseType.CANCEL,
-				DesktopFolder.Lang.DIALOG_SELECT,
-				Gtk.ResponseType.ACCEPT);
+    /**
+     * @name create_new_photo
+     * @param {Gtk.Window} window the parent window to show the dialog
+     * @description show a dialog to create a new photo
+     */
+    public static void create_new_photo (Gtk.Window window) {
+        Gtk.FileChooserDialog chooser = new Gtk.FileChooserDialog (
+            DesktopFolder.Lang.PHOTO_SELECT_PHOTO_MESSAGE, window,
+            Gtk.FileChooserAction.OPEN,
+            DesktopFolder.Lang.DIALOG_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            DesktopFolder.Lang.DIALOG_SELECT,
+            Gtk.ResponseType.ACCEPT);
 
-		Gtk.FileFilter filter = new Gtk.FileFilter();
-		filter.set_name("Images");
-		filter.add_mime_type("image");
-		filter.add_mime_type("image/png");
-		filter.add_mime_type("image/jpeg");
-		filter.add_mime_type("image/gif");
-		filter.add_pattern("*.png");
-		filter.add_pattern("*.jpg");
-		filter.add_pattern("*.gif");
-		filter.add_pattern("*.tif");
-		filter.add_pattern("*.xpm");
-		chooser.add_filter(filter);
+        Gtk.FileFilter filter = new Gtk.FileFilter ();
+        filter.set_name ("Images");
+        filter.add_mime_type ("image");
+        filter.add_mime_type ("image/png");
+        filter.add_mime_type ("image/jpeg");
+        filter.add_mime_type ("image/gif");
+        filter.add_pattern ("*.png");
+        filter.add_pattern ("*.jpg");
+        filter.add_pattern ("*.gif");
+        filter.add_pattern ("*.tif");
+        filter.add_pattern ("*.xpm");
+        chooser.add_filter (filter);
 
 
-		// Process response:
-		if (chooser.run () == Gtk.ResponseType.ACCEPT) {
-			  var photo_path=chooser.get_filename();
-			  PhotoSettings ps=new PhotoSettings(photo_path);
-	          string path=DesktopFolderApp.get_app_folder()+"/"+ps.name+"."+DesktopFolder.PHOTO_EXTENSION;
-	          File f=File.new_for_path (path);
-	          ps.save_to_file(f);
-		}
-		chooser.close();
-	}
+        // Process response:
+        if (chooser.run () == Gtk.ResponseType.ACCEPT) {
+            var           photo_path = chooser.get_filename ();
+            PhotoSettings ps         = new PhotoSettings (photo_path);
+            string        path       = DesktopFolderApp.get_app_folder () + "/" + ps.name + "." + DesktopFolder.PHOTO_EXTENSION;
+            File          f          = File.new_for_path (path);
+            ps.save_to_file (f);
+        }
+        chooser.close ();
+    }
 
-
-	/**
-    * @name create_new_desktop_folder
-    * @description create a new folder inside the desktop
-	* @param {Gtk.Window} window the parent window to show the dialog
-    */
-    public static void create_new_desktop_folder(Gtk.Window window){
-		RenameDialog dialog = new RenameDialog (window,
+    /**
+     * @name create_new_desktop_folder
+     * @description create a new folder inside the desktop
+     * @param {Gtk.Window} window the parent window to show the dialog
+     */
+    public static void create_new_desktop_folder (Gtk.Window window) {
+        RenameDialog dialog = new RenameDialog (window,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_ENTER_TITLE,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_ENTER_NAME,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW);
-        dialog.on_rename.connect((new_name)=>{
-            //creating the folder
-            if(new_name!=""){
-				//cancelling the current monitor
-		        DirUtils.create(DesktopFolderApp.get_app_folder()+"/"+new_name,0755);
+        dialog.on_rename.connect ((new_name) => {
+            // creating the folder
+            if (new_name != "") {
+                // cancelling the current monitor
+                DirUtils.create (DesktopFolderApp.get_app_folder () + "/" + new_name, 0755);
             }
         });
         dialog.show_all ();
     }
 
     /**
-    * @name create_new_note
-    * @description create a new note inside the desktop
-	* @param {Gtk.Window} window the parent window to show the dialog
-    */
-    public static void create_new_note(Gtk.Window window){
-		RenameDialog dialog = new RenameDialog (window,
-												DesktopFolder.Lang.NOTE_ENTER_TITLE,
-												DesktopFolder.Lang.NOTE_ENTER_NAME,
-												DesktopFolder.Lang.NOTE_NEW);
-		dialog.on_rename.connect((new_name)=>{
-			//creating the folder
-			if(new_name!=""){
-				NoteSettings ns=new NoteSettings(new_name);
-		        string path=DesktopFolderApp.get_app_folder()+"/"+new_name+"."+DesktopFolder.NOTE_EXTENSION;
-		        File f=File.new_for_path (path);
-		        ns.save_to_file(f);
-			}
-		});
-		dialog.show_all ();
+     * @name create_new_note
+     * @description create a new note inside the desktop
+     * @param {Gtk.Window} window the parent window to show the dialog
+     */
+    public static void create_new_note (Gtk.Window window) {
+        RenameDialog dialog = new RenameDialog (window,
+                                                DesktopFolder.Lang.NOTE_ENTER_TITLE,
+                                                DesktopFolder.Lang.NOTE_ENTER_NAME,
+                                                DesktopFolder.Lang.NOTE_NEW);
+        dialog.on_rename.connect ((new_name) => {
+            // creating the folder
+            if (new_name != "") {
+                NoteSettings ns = new NoteSettings (new_name);
+                string path     = DesktopFolderApp.get_app_folder () + "/" + new_name + "." + DesktopFolder.NOTE_EXTENSION;
+                File f          = File.new_for_path (path);
+                ns.save_to_file (f);
+            }
+        });
+        dialog.show_all ();
     }
 
-	/**
-	* @name blur_image_surface
-	* @description Performs a simple 2D Gaussian blur of radius @radius on surface @surface.
-	*/
-	public static void blur_image_surface (Cairo.ImageSurface surface, int radius) {
-		debug("start blur1");
+    /**
+     * @name blur_image_surface
+     * @description Performs a simple 2D Gaussian blur of radius @radius on surface @surface.
+     */
+    public static void blur_image_surface (Cairo.ImageSurface surface, int radius) {
+        debug ("start blur1");
 
-		Cairo.ImageSurface tmp;
-		int width, height;
-		int src_stride, dst_stride;
-		int x, y, z, w;
-		uchar[] src;
-		uchar[] dst;
-		int s, d;
-		uint32 a, p;
-		int i, j, k;
-		uint8 kernel[17];
-		int size =(int) (17 / sizeof (uint8));
-		int half =(int) ((17 / sizeof(uint8)) / 2);
+        Cairo.ImageSurface tmp;
+        int     width, height;
+        int     src_stride, dst_stride;
+        int     x, y, z, w;
+        uchar[] src;
+        uchar[] dst;
+        int     s, d;
+        uint32  a, p;
+        int     i, j, k;
+        uint8   kernel[17];
+        int     size = (int) (17 / sizeof (uint8));
+        int     half = (int) ((17 / sizeof (uint8)) / 2);
 
-		if (surface.status()!=Cairo.Status.SUCCESS){
-			return;
-		}
+        if (surface.status () != Cairo.Status.SUCCESS) {
+            return;
+        }
 
-		width = surface.get_width ();
-		height = surface.get_height ();
+        width  = surface.get_width ();
+        height = surface.get_height ();
 
-		debug("start blur2");
+        debug ("start blur2");
 
-		switch (surface.get_format()) {
-			case Cairo.Format.A1:
-			default:
-				/* Don't even think about it! */
-				return;
-			case Cairo.Format.A8:
-				/* Handle a8 surfaces by effectively unrolling the loops by a
-				* factor of 4 - this is safe since we know that stride has to be a
-				* multiple of uint32_t. */
-				width = width / 4;
-				break;
-			case Cairo.Format.RGB24:
-			case Cairo.Format.ARGB32:
-				break;
-		}
+        switch (surface.get_format ()) {
+        case Cairo.Format.A1:
+        default:
+            /* Don't even think about it! */
+            return;
+        case Cairo.Format.A8:
+            /* Handle a8 surfaces by effectively unrolling the loops by a
+             * factor of 4 - this is safe since we know that stride has to be a
+             * multiple of uint32_t. */
+            width = width / 4;
+            break;
+        case Cairo.Format.RGB24:
+        case Cairo.Format.ARGB32:
+            break;
+        }
 
-		debug("start blur2.1");
+        debug ("start blur2.1");
 
-		tmp = new Cairo.ImageSurface(Cairo.Format.ARGB32, width, height);
-		if (tmp.status()!=Cairo.Status.SUCCESS)
-			return;
+        tmp = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
+        if (tmp.status () != Cairo.Status.SUCCESS)
+            return;
 
-			debug("start blur2.2");
-		src = surface.get_data();
-		debug("start blur2.3");
-		src_stride = surface.get_stride();
-		debug("start blur2.4");
+        debug ("start blur2.2");
+        src        = surface.get_data ();
+        debug ("start blur2.3");
+        src_stride = surface.get_stride ();
+        debug ("start blur2.4");
 
-		debug("start blur2.5");
+        debug ("start blur2.5");
 
-		dst = tmp.get_data();
-		dst_stride = tmp.get_stride();
+        dst        = tmp.get_data ();
+        dst_stride = tmp.get_stride ();
 
-		debug("start blur3");
+        debug ("start blur3");
 
-		a = 0;
-		for (i = 0; i < size; i++) {
-			double f = i - half;
-			kernel[i] = (uint8) (Math.exp (- f * f / 30.0) * 80);
-			a = a+kernel[i];
-		}
+        a = 0;
+        for (i = 0 ; i < size ; i++) {
+            double f = i - half;
+            kernel[i] = (uint8) (Math.exp (-f * f / 30.0) * 80);
+            a         = a + kernel[i];
+        }
 
-		/* Horizontally blur from surface -> tmp */
-		for (i = 0; i < height; i++) {
-			s = i*src_stride;
-			d = i*dst_stride;
-			for (j = 0; j < width; j++) {
-				if (radius < j && j < width - radius) {
-					dst[d+j] = src[s+j];
-					continue;
-				}
+        /* Horizontally blur from surface -> tmp */
+        for (i = 0 ; i < height ; i++) {
+            s = i * src_stride;
+            d = i * dst_stride;
+            for (j = 0 ; j < width ; j++) {
+                if (radius < j && j < width - radius) {
+                    dst[d + j] = src[s + j];
+                    continue;
+                }
 
-				x = y = z = w = 0;
-				for (k = 0; k < size; k++) {
-					if (j - half + k < 0 || j - half + k >= width){
-						continue;
-					}
+                x = y = z = w = 0;
+                for (k = 0 ; k < size ; k++) {
+                    if (j - half + k < 0 || j - half + k >= width) {
+                        continue;
+                    }
 
-					p = src[s+ j - half + k];
+                    p = src[s + j - half + k];
 
-					x = x + (int) (((p >> 24) & 0xff) * kernel[k]);
-					y = y + (int) (((p >> 16) & 0xff) * kernel[k]);
-					z = z + (int) (((p >>  8) & 0xff) * kernel[k]);
-					w = w + (int) (((p >>  0) & 0xff) * kernel[k]);
-				}
-				dst[d+j] = (uchar) ((x / a << 24) | (y / a << 16) | (z / a << 8) | w / a);
-			}
-		}
+                    x = x + (int) (((p >> 24) & 0xff) * kernel[k]);
+                    y = y + (int) (((p >> 16) & 0xff) * kernel[k]);
+                    z = z + (int) (((p >> 8) & 0xff) * kernel[k]);
+                    w = w + (int) (((p >> 0) & 0xff) * kernel[k]);
+                }
+                dst[d + j] = (uchar) ((x / a << 24) | (y / a << 16) | (z / a << 8) | w / a);
+            }
+        }
 
-		debug("start blur4");
+        debug ("start blur4");
 
-		/* Then vertically blur from tmp -> surface */
-		for (i = 0; i < height; i++) {
-			s = i* dst_stride;
-			d = i * src_stride;
-			for (j = 0; j < width; j++) {
-				if (radius <= i && i < height - radius) {
-					src[j] = dst[j];
-					continue;
-				}
+        /* Then vertically blur from tmp -> surface */
+        for (i = 0 ; i < height ; i++) {
+            s = i * dst_stride;
+            d = i * src_stride;
+            for (j = 0 ; j < width ; j++) {
+                if (radius <= i && i < height - radius) {
+                    src[j] = dst[j];
+                    continue;
+                }
 
-				x = y = z = w = 0;
-				for (k = 0; k < size; k++) {
-					if (i - half + k < 0 || i - half + k >= height){
-						continue;
-					}
+                x = y = z = w = 0;
+                for (k = 0 ; k < size ; k++) {
+                    if (i - half + k < 0 || i - half + k >= height) {
+                        continue;
+                    }
 
-					s = (i - half + k) * dst_stride;
-					p = dst[s+j];
+                    s = (i - half + k) * dst_stride;
+                    p = dst[s + j];
 
-					x = x + (int) (((p >> 24) & 0xff) * kernel[k]);
-					y = y + (int) (((p >> 16) & 0xff) * kernel[k]);
-					z = z + (int) (((p >>  8) & 0xff) * kernel[k]);
-					w = w + (int) (((p >>  0) & 0xff) * kernel[k]);
-				}
-				src[d+j] = (uchar) ((x / a << 24) | (y / a << 16) | (z / a << 8) | w / a);
-			}
-		}
+                    x = x + (int) (((p >> 24) & 0xff) * kernel[k]);
+                    y = y + (int) (((p >> 16) & 0xff) * kernel[k]);
+                    z = z + (int) (((p >> 8) & 0xff) * kernel[k]);
+                    w = w + (int) (((p >> 0) & 0xff) * kernel[k]);
+                }
+                src[d + j] = (uchar) ((x / a << 24) | (y / a << 16) | (z / a << 8) | w / a);
+            }
+        }
 
-		debug("start blur5");
+        debug ("start blur5");
 
-		//cairo_surface_destroy (tmp);
-		surface.mark_dirty ();
-	}
+        // cairo_surface_destroy (tmp);
+        surface.mark_dirty ();
+    }
 
 }

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -62,7 +62,7 @@ namespace DesktopFolder.Util {
             string src_path                = src.get_path ();
             string dest_path               = dest.get_path ();
             GLib.FileEnumerator enumerator = src.enumerate_children (GLib.FileAttribute.STANDARD_NAME, GLib.FileQueryInfoFlags.NONE, cancellable);
-            for (GLib.FileInfo ? info = enumerator.next_file (cancellable) ; info != null ; info = enumerator.next_file (cancellable)) {
+            for (GLib.FileInfo ? info = enumerator.next_file (cancellable); info != null; info = enumerator.next_file (cancellable)) {
                 copy_recursive (
                     GLib.File.new_for_path (GLib.Path.build_filename (src_path, info.get_name ())),
                     GLib.File.new_for_path (GLib.Path.build_filename (dest_path, info.get_name ())),
@@ -263,24 +263,24 @@ namespace DesktopFolder.Util {
         debug ("start blur3");
 
         a = 0;
-        for (i = 0 ; i < size ; i++) {
+        for (i = 0; i < size; i++) {
             double f = i - half;
             kernel[i] = (uint8) (Math.exp (-f * f / 30.0) * 80);
             a         = a + kernel[i];
         }
 
         /* Horizontally blur from surface -> tmp */
-        for (i = 0 ; i < height ; i++) {
+        for (i = 0; i < height; i++) {
             s = i * src_stride;
             d = i * dst_stride;
-            for (j = 0 ; j < width ; j++) {
+            for (j = 0; j < width; j++) {
                 if (radius < j && j < width - radius) {
                     dst[d + j] = src[s + j];
                     continue;
                 }
 
                 x = y = z = w = 0;
-                for (k = 0 ; k < size ; k++) {
+                for (k = 0; k < size; k++) {
                     if (j - half + k < 0 || j - half + k >= width) {
                         continue;
                     }
@@ -299,17 +299,17 @@ namespace DesktopFolder.Util {
         debug ("start blur4");
 
         /* Then vertically blur from tmp -> surface */
-        for (i = 0 ; i < height ; i++) {
+        for (i = 0; i < height; i++) {
             s = i * dst_stride;
             d = i * src_stride;
-            for (j = 0 ; j < width ; j++) {
+            for (j = 0; j < width; j++) {
                 if (radius <= i && i < height - radius) {
                     src[j] = dst[j];
                     continue;
                 }
 
                 x = y = z = w = 0;
-                for (k = 0 ; k < size ; k++) {
+                for (k = 0; k < size; k++) {
                     if (i - half + k < 0 || i - half + k >= height) {
                         continue;
                     }

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -134,7 +134,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
             this.move (settings.x, settings.y);
         }
         List<unowned string> classes = this.get_style_context ().list_classes ();
-        for (int i = 0 ; i < classes.length () ; i++) {
+        for (int i = 0; i < classes.length (); i++) {
             string class = classes.nth_data (i);
             if (class.has_prefix ("df_")) {
                 this.get_style_context ().remove_class (class);
@@ -420,7 +420,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
 
         // finally we show the popup
         menu.popup (
-            null  // parent menu shell
+            null // parent menu shell
             , null // parent menu item
             , null // func
             , event.button // button
@@ -494,7 +494,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      */
     private void change_head_color (int ncolor) {
         string color = HEAD_TAGS_COLORS_CLASS[ncolor];
-        for (int i = 0 ; i < HEAD_TAGS_COLORS_CLASS.length ; i++) {
+        for (int i = 0; i < HEAD_TAGS_COLORS_CLASS.length; i++) {
             string scolor = HEAD_TAGS_COLORS_CLASS[i];
             this.get_style_context ().remove_class (scolor);
         }
@@ -520,7 +520,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      */
     private void change_body_color (int ncolor) {
         string color = BODY_TAGS_COLORS_CLASS[ncolor];
-        for (int i = 0 ; i < BODY_TAGS_COLORS_CLASS.length ; i++) {
+        for (int i = 0; i < BODY_TAGS_COLORS_CLASS.length; i++) {
             string scolor = BODY_TAGS_COLORS_CLASS[i];
             this.get_style_context ().remove_class (scolor);
         }
@@ -703,7 +703,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
                     // If this is the first element is selectable found
                     next_allocation = elem_allocation;
                     next_item       = (ItemView) elem;
-                } else if (!is_selectable (elem_allocation, next_allocation))    {
+                } else if (!is_selectable (elem_allocation, next_allocation)) {
                     // If it is nearer from the last found
                     next_allocation = elem_allocation;
                     next_item       = (ItemView) elem;
@@ -724,7 +724,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      */
     private ItemView get_selected_item () {
         var children = this.container.get_children ();
-        for (int i = 0 ; i < children.length () ; i++) {
+        for (int i = 0; i < children.length (); i++) {
             ItemView element = (ItemView) children.nth_data (i);
             if (element.is_selected ()) {
                 return element;
@@ -903,8 +903,8 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
             int margin      = 10;
             int sensitivity = SENSITIVITY_WITH_GRID - 10;
             cr.set_source_rgba (1, 1, 1, 0.3);
-            for (int i = padding ; i < width - paddingx2 ; i = i + sensitivity + margin) {
-                for (int j = padding + header ; j < height - paddingx2 ; j = j + sensitivity + margin) {
+            for (int i = padding; i < width - paddingx2; i = i + sensitivity + margin) {
+                for (int j = padding + header; j < height - paddingx2; j = j + sensitivity + margin) {
                     cr.rectangle (i, j, sensitivity, sensitivity);
                     cr.fill ();
                 }

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -578,7 +578,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         // this is the delete key code
         const int DELETE_KEY      = 65535;
         const int F2_KEY          = 65471;
-        const int INTRO_KEY       = 65293;
+        const int ENTER_KEY       = 65293;
         const int ARROW_LEFT_KEY  = 65361;
         const int ARROW_UP_KEY    = 65362;
         const int ARROW_RIGHT_KEY = 65363;
@@ -587,82 +587,83 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         // check if the control key is pressed
         var  mods            = event.state & Gtk.accelerator_get_default_mod_mask ();
         bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
+        bool shift_pressed   = ((mods & Gdk.ModifierType.SHIFT_MASK) != 0);
 
-        if (event.type == Gdk.EventType.KEY_RELEASE && key == DELETE_KEY) {
-            // delete key pressed!
-            ItemView selected = this.get_selected_item ();
-            if (selected != null) {
-                selected.delete_dialog ();
-                return true;
+        ItemView selected    = this.get_selected_item ();
+
+        if (event.type == Gdk.EventType.KEY_RELEASE) {
+            if (control_pressed) {
+                if (key == 'c' || key == 'C') {
+                    if (selected != null) {
+                        selected.copy ();
+                        return true;
+                    }
+                } else if (key == 'x' || key == 'X') {
+                    if (selected != null) {
+                        selected.cut ();
+                        return true;
+                    }
+                } else if (key == 'v' || key == 'V') {
+                    this.manager.paste ();
+                }
             } else {
-                this.manager.trash ();
+                if (key == DELETE_KEY) {
+                    if (selected != null) {
+                        if (shift_pressed) {
+                            selected.delete_dialog ();
+                        } else {
+                            selected.move_to_trash ();
+                        }
+                        return true;
+                    } else {
+                        this.manager.move_to_trash ();
+                    }
+                } else if (key == F2_KEY) {
+                    if (selected != null) {
+                        selected.rename_dialog ();
+                        return true;
+                    } else {
+                        this.rename_folder ();
+                    }
+                } else if (key == ENTER_KEY) {
+                    if (selected != null) {
+                        selected.execute ();
+                        return true;
+                    }
+                }
             }
-            return false;
-        } else if (event.type == Gdk.EventType.KEY_RELEASE && key == F2_KEY)       {
-            // ctrl+c key pressed
-            ItemView selected = this.get_selected_item ();
-            if (selected != null) {
-                selected.rename_dialog ();
-                return true;
-            } else {
-                this.rename_folder ();
+        } else if (event.type == Gdk.EventType.KEY_PRESS) {
+            if (key == ARROW_LEFT_KEY) {
+                // left arrow pressed
+                move_selected_to ((a, b) => {
+                    return (b.y >= a.y && b.y <= (a.y + a.height)) || (a.y >= b.y && a.y <= (b.y + b.height));
+                }, (a, b) => {
+                    return a.x < b.x;
+                });
+            } else if (key == ARROW_UP_KEY) {
+                // up arrow pressed
+                move_selected_to ((a, b) => {
+                    return (b.x >= a.x && b.x <= (a.x + a.width)) || (a.x >= b.x && a.x <= (b.x + b.width));
+                }, (a, b) => {
+                    return a.y < b.y;
+                });
+            } else if (key == ARROW_RIGHT_KEY) {
+                // right arrow pressed
+                move_selected_to ((a, b) => {
+                    return (b.y >= a.y && b.y <= (a.y + a.height)) || (a.y >= b.y && a.y <= (b.y + b.height));
+                }, (a, b) => {
+                    return a.x > b.x;
+                });
+            } else if (key == ARROW_DOWN_KEY) {
+                // down arrow pressed
+                move_selected_to ((a, b) => {
+                    return (b.x >= a.x && b.x <= (a.x + a.width)) || (a.x >= b.x && a.x <= (b.x + b.width));
+                }, (a, b) => {
+                    return a.y > b.y;
+                });
             }
-            return false;
-        } else if (control_pressed && event.type == Gdk.EventType.KEY_RELEASE && (key == 'c' || key == 'C'))         {
-            // ctrl+c key pressed
-            ItemView selected = this.get_selected_item ();
-            if (selected != null) {
-                selected.copy ();
-                return true;
-            }
-            return false;
-        } else if (control_pressed && event.type == Gdk.EventType.KEY_RELEASE && (key == 'x' || key == 'X'))         {
-            // ctrl+x key pressed
-            ItemView selected = this.get_selected_item ();
-            if (selected != null) {
-                selected.cut ();
-                return true;
-            }
-            return false;
-        } else if (control_pressed && event.type == Gdk.EventType.KEY_RELEASE && (key == 'v' || key == 'V'))         {
-            // ctrl+v key pressed
-            this.manager.paste ();
-        } else if (event.type == Gdk.EventType.KEY_RELEASE && key == INTRO_KEY)       {
-            // INTRO key pressed
-            ItemView selected = this.get_selected_item ();
-            if (selected != null) {
-                selected.execute ();
-                return true;
-            }
-        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_LEFT_KEY)       {
-            // left arrow pressed
-            move_selected_to ((a, b) => {
-                return (b.y >= a.y && b.y <= (a.y + a.height)) || (a.y >= b.y && a.y <= (b.y + b.height));
-            }, (a, b) => {
-                return a.x < b.x;
-            });
-        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_UP_KEY)       {
-            // up arrow pressed
-            move_selected_to ((a, b) => {
-                return (b.x >= a.x && b.x <= (a.x + a.width)) || (a.x >= b.x && a.x <= (b.x + b.width));
-            }, (a, b) => {
-                return a.y < b.y;
-            });
-        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_RIGHT_KEY)       {
-            // right arrow pressed
-            move_selected_to ((a, b) => {
-                return (b.y >= a.y && b.y <= (a.y + a.height)) || (a.y >= b.y && a.y <= (b.y + b.height));
-            }, (a, b) => {
-                return a.x > b.x;
-            });
-        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_DOWN_KEY)       {
-            // down arrow pressed
-            move_selected_to ((a, b) => {
-                return (b.x >= a.x && b.x <= (a.x + a.width)) || (a.x >= b.x && a.x <= (b.x + b.width));
-            }, (a, b) => {
-                return a.y > b.y;
-            });
         }
+
         return false;
     }
 

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -371,7 +371,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
 
         // option to delete the current folder
         item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER);
-        item.activate.connect ((item) => { this.manager.delete (); });
+        item.activate.connect ((item) => { this.manager.trash (); });
         item.show ();
         menu.append (item);
 
@@ -595,7 +595,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
                 selected.delete_dialog ();
                 return true;
             } else {
-                this.manager.delete ();
+                this.manager.trash ();
             }
             return false;
         } else if (event.type == Gdk.EventType.KEY_RELEASE && key == F2_KEY)       {

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -612,11 +612,11 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
                         if (shift_pressed) {
                             selected.delete_dialog ();
                         } else {
-                            selected.move_to_trash ();
+                            selected.trash ();
                         }
                         return true;
                     } else {
-                        this.manager.move_to_trash ();
+                        this.manager.trash ();
                     }
                 } else if (key == F2_KEY) {
                     if (selected != null) {

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -1,251 +1,253 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Folder Window that is shown above the desktop to manage files and folders
-*/
-public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow{
+ * @class
+ * Folder Window that is shown above the desktop to manage files and folders
+ */
+public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
     /** parent manager of this window */
-    private FolderManager manager=null;
+    private FolderManager manager = null;
     /** container of widgets */
-    private Gtk.Fixed container=null;
+    private Gtk.Fixed container   = null;
     /** Context menu of the Folder Window */
-    private Gtk.Menu menu=null;
+    private Gtk.Menu menu         = null;
 
     /** flag to know if an icon is moving*/
-    private bool flag_moving=false;
+    private bool flag_moving = false;
 
     /** item alignment*/
-    private const int SENSITIVITY_WITH_GRID = 101;
+    private const int SENSITIVITY_WITH_GRID    = 101;
     private const int SENSITIVITY_WITHOUT_GRID = 4;
-    //TODO: private int _sensitivity {public get;public set; default=SENSITIVITY_WITHOUT_GRID;}
-    private int sensitivity = SENSITIVITY_WITHOUT_GRID;
+    // TODO: private int _sensitivity {public get;public set; default=SENSITIVITY_WITHOUT_GRID;}
+    private int sensitivity                    = SENSITIVITY_WITHOUT_GRID;
 
     /** head tags colors */
-    private const string HEAD_TAGS_COLORS[3] = { null, "#ffffff", "#000000"};
-    private const string HEAD_TAGS_COLORS_CLASS[3] = { "df_headless", "df_light", "df_dark"};
+    private const string HEAD_TAGS_COLORS[3]        = { null, "#ffffff", "#000000" };
+    private const string HEAD_TAGS_COLORS_CLASS[3]  = { "df_headless", "df_light", "df_dark" };
     /** body tags colors */
-    private const string BODY_TAGS_COLORS[10] = { null, "#ffe16b", "#ffa154", "#795548", "#9bdb4d", "#64baff", "#ad65d6", "#ed5353", "#d4d4d4", "#000000" };
+    private const string BODY_TAGS_COLORS[10]       = { null, "#ffe16b", "#ffa154", "#795548", "#9bdb4d", "#64baff", "#ad65d6", "#ed5353", "#d4d4d4", "#000000" };
     private const string BODY_TAGS_COLORS_CLASS[10] = { "df_transparent", "df_yellow", "df_orange", "df_brown", "df_green", "df_blue", "df_purple", "df_red", "df_gray", "df_black" };
 
     construct {
         set_keep_below (true);
         this.hide_titlebar_when_maximized = false;
-        set_type_hint(Gdk.WindowTypeHint.DESKTOP);
+        set_type_hint (Gdk.WindowTypeHint.DESKTOP);
 
-        set_skip_taskbar_hint(true);
-        this.set_property("skip-taskbar-hint", true);
-        this.set_property("skip-pager-hint", true);
-        this.set_property("skip_taskbar_hint", true);
-        this.set_property("skip_pager_hint", true);
-        this.skip_pager_hint = true;
+        set_skip_taskbar_hint (true);
+        this.set_property ("skip-taskbar-hint", true);
+        this.set_property ("skip-pager-hint", true);
+        this.set_property ("skip_taskbar_hint", true);
+        this.set_property ("skip_pager_hint", true);
+        this.skip_pager_hint   = true;
         this.skip_taskbar_hint = true;
 
         stick ();
     }
 
     /**
-    * @constructor
-    * @param FolderManager manager the manager of this window
-    */
-    public FolderWindow (FolderManager manager){
-        Object (application: manager.get_application(),
-                icon_name: "com.github.spheras.desktopfolder",
-                resizable: true,
-                accept_focus:true,
-                skip_taskbar_hint : true,
-                skip_pager_hint:true,
-                decorated:true,
-                title: (manager.get_folder_name()),
-                type_hint:Gdk.WindowTypeHint.DESKTOP,
-                deletable:false,
-                default_width:300,
-                default_height:300,
-                height_request: 50,
-                width_request: 50);
+     * @constructor
+     * @param FolderManager manager the manager of this window
+     */
+    public FolderWindow (FolderManager manager) {
+        Object (
+            application:        manager.get_application (),
+            icon_name:          "com.github.spheras.desktopfolder",
+            resizable:          true,
+            accept_focus:       true,
+            skip_taskbar_hint:  true,
+            skip_pager_hint:    true,
+            decorated:          true,
+            title:              (manager.get_folder_name ()),
+            type_hint:          Gdk.WindowTypeHint.DESKTOP,
+            deletable:          false,
+            default_width:      300,
+            default_height:     300,
+            height_request:     50,
+            width_request:      50
+        );
 
 
-        var headerbar = new Gtk.HeaderBar();
-        headerbar.set_title(manager.get_folder_name());
-        //headerbar.set_subtitle("HeaderBar Subtitle");
-        //headerbar.set_show_close_button(true);
-        this.set_titlebar(headerbar);
+        var headerbar = new Gtk.HeaderBar ();
+        headerbar.set_title (manager.get_folder_name ());
+        // headerbar.set_subtitle("HeaderBar Subtitle");
+        // headerbar.set_show_close_button(true);
+        this.set_titlebar (headerbar);
 
-        this.set_skip_taskbar_hint(true);
-        skip_pager_hint = true;
+        this.set_skip_taskbar_hint (true);
+        skip_pager_hint   = true;
         skip_taskbar_hint = true;
-        this.set_property("skip-taskbar-hint", true);
-        //setting the folder name
-        this.manager=manager;
+        this.set_property ("skip-taskbar-hint", true);
+        // setting the folder name
+        this.manager = manager;
 
-        //creating the container widget
-        this.container=new Gtk.Fixed();
-        add(this.container);
+        // creating the container widget
+        this.container = new Gtk.Fixed ();
+        add (this.container);
 
-        this.reload_settings();
+        this.reload_settings ();
 
-        //connecting to events
+        // connecting to events
         this.configure_event.connect (this.on_configure);
-        this.button_press_event.connect(this.on_press);
-        this.button_release_event.connect(this.on_release);
-        this.key_release_event.connect(this.on_key);
-        this.key_press_event.connect(this.on_key);
-        this.draw.connect(this.draw_background);
+        this.button_press_event.connect (this.on_press);
+        this.button_release_event.connect (this.on_release);
+        this.key_release_event.connect (this.on_key);
+        this.key_press_event.connect (this.on_key);
+        this.draw.connect (this.draw_background);
 
-        //help: doesn't have the gtk window any active signal? or css :active state?
-        Wnck.Screen screen = Wnck.Screen.get_default();
-        screen.active_window_changed.connect(on_active_change);
+        // help: doesn't have the gtk window any active signal? or css :active state?
+        Wnck.Screen screen = Wnck.Screen.get_default ();
+        screen.active_window_changed.connect (on_active_change);
 
         /*
-        this.focus_in_event.connect((event)=>{debug("focus_in");return false;});
-        this.focus_out_event.connect((event)=>{on_blur(event);debug("focus_out");return false;});
-        this.default_activated.connect((event)=>{debug("default_activated");});
-        this.focus_activated.connect(()=>{debug("focus_activated");});
-        this.window_state_event.connect(on_window_state_event);
-        */
-        //TODO this.dnd_behaviour=new DragnDrop.DndBehaviour(this,false, true);
+           this.focus_in_event.connect((event)=>{debug("focus_in");return false;});
+           this.focus_out_event.connect((event)=>{on_blur(event);debug("focus_out");return false;});
+           this.default_activated.connect((event)=>{debug("default_activated");});
+           this.focus_activated.connect(()=>{debug("focus_activated");});
+           this.window_state_event.connect(on_window_state_event);
+         */
+        // TODO this.dnd_behaviour=new DragnDrop.DndBehaviour(this,false, true);
     }
 
-    public void reload_settings(){
-        //let's load the settings of the folder (if exist or a new one)
-        FolderSettings settings=this.manager.get_settings();
-        if(settings.w>0){
-            //applying existing position and size configuration
-            this.resize(settings.w,settings.h);
-            this.move(settings.x,settings.y);
+    public void reload_settings () {
+        // let's load the settings of the folder (if exist or a new one)
+        FolderSettings settings = this.manager.get_settings ();
+        if (settings.w > 0) {
+            // applying existing position and size configuration
+            this.resize (settings.w, settings.h);
+            this.move (settings.x, settings.y);
         }
-        List<unowned string> classes=this.get_style_context().list_classes();
-        for(int i=0;i<classes.length();i++){
-            string class=classes.nth_data(i);
-            if(class.has_prefix("df_")){
-                this.get_style_context().remove_class(class);
+        List<unowned string> classes = this.get_style_context ().list_classes ();
+        for (int i = 0 ; i < classes.length () ; i++) {
+            string class = classes.nth_data (i);
+            if (class.has_prefix ("df_")) {
+                this.get_style_context ().remove_class (class);
             }
         }
-        //we set a class to this window to manage the css
+        // we set a class to this window to manage the css
         this.get_style_context ().add_class ("df_folder");
 
-        //applying existing colors configuration
+        // applying existing colors configuration
         this.get_style_context ().add_class (settings.bgcolor);
         this.get_style_context ().add_class (settings.fgcolor);
 
-        if(this.manager.get_settings().textshadow){
+        if (this.manager.get_settings ().textshadow) {
             this.get_style_context ().add_class ("df_shadow");
         }
-        if(this.manager.get_settings().textbold){
+        if (this.manager.get_settings ().textbold) {
             this.get_style_context ().add_class ("df_bold");
         }
 
-        this.set_title(manager.get_folder_name());
+        this.set_title (manager.get_folder_name ());
 
-        if(this.manager.get_settings().align_to_grid){
+        if (this.manager.get_settings ().align_to_grid) {
             this.sensitivity = SENSITIVITY_WITH_GRID;
-        }else{
+        } else {
             this.sensitivity = SENSITIVITY_WITHOUT_GRID;
         }
     }
 
     /**
-    * @name on_active_change
-    * @description the screen actived window has change signal
-    * @param {Wnck.Window} the previous actived window
-    */
-    private void on_active_change(Wnck.Window? previous){
-        string sclass="df_active";
-        Gtk.StyleContext style=this.get_style_context();
-        //debug("%s is active? %s",this.manager.get_folder_name(), this.is_active ? "true" : "false");
-        if(this.is_active){
-            if(!style.has_class(sclass)){
+     * @name on_active_change
+     * @description the screen actived window has change signal
+     * @param {Wnck.Window} the previous actived window
+     */
+    private void on_active_change (Wnck.Window ? previous) {
+        string           sclass = "df_active";
+        Gtk.StyleContext style  = this.get_style_context ();
+        // debug("%s is active? %s",this.manager.get_folder_name(), this.is_active ? "true" : "false");
+        if (this.is_active) {
+            if (!style.has_class (sclass)) {
                 style.add_class ("df_active");
-                //we need to force a queue_draw
-                this.queue_draw();
+                // we need to force a queue_draw
+                this.queue_draw ();
             }
-        }else{
-            if(style.has_class(sclass)){
+        } else {
+            if (style.has_class (sclass)) {
                 style.remove_class ("df_active");
-                this.type_hint=Gdk.WindowTypeHint.DESKTOP;
-                //we need to force a queue_draw
-                this.queue_draw();
+                this.type_hint = Gdk.WindowTypeHint.DESKTOP;
+                // we need to force a queue_draw
+                this.queue_draw ();
             }
         }
     }
 
     /**
-    * @name refresh
-    * @description refresh the window
-    */
-    public void refresh(){
-        this.show_all();
+     * @name refresh
+     * @description refresh the window
+     */
+    public void refresh () {
+        this.show_all ();
     }
 
     /**
-    * @name on_configure
-    * @description the configure event is produced when the window change its dimensions or location settings
-    */
-    private bool on_configure(Gdk.EventConfigure event){
-        if(event.type==Gdk.EventType.CONFIGURE){
-            //we are now a dock Window, to avoid minimization when show desktop
-            //TODO exists a way to make resizable and moveable a dock window?
-            this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_configure
+     * @description the configure event is produced when the window change its dimensions or location settings
+     */
+    private bool on_configure (Gdk.EventConfigure event) {
+        if (event.type == Gdk.EventType.CONFIGURE) {
+            // we are now a dock Window, to avoid minimization when show desktop
+            // TODO exists a way to make resizable and moveable a dock window?
+            this.type_hint = Gdk.WindowTypeHint.DESKTOP;
 
-            //debug("configure event:%i,%i,%i,%i",event.x,event.y,event.width,event.height);
-            this.manager.set_new_shape(event.x, event.y, event.width, event.height);
+            // debug("configure event:%i,%i,%i,%i",event.x,event.y,event.width,event.height);
+            this.manager.set_new_shape (event.x, event.y, event.width, event.height);
         }
         return false;
     }
 
     /**
-    * @name on_release
-    * @description release event captured.
-    * @return bool @see widget on_release signal
-    */
-    private bool on_release(Gdk.EventButton event){
-        //we are now a dock Window, to avoid minimization when show desktop
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_release
+     * @description release event captured.
+     * @return bool @see widget on_release signal
+     */
+    private bool on_release (Gdk.EventButton event) {
+        // we are now a dock Window, to avoid minimization when show desktop
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
         return false;
     }
 
     /**
-    * @name on_press
-    * @description press event captured. The Window should show the popup on right button
-    * @return bool @see widget on_press signal
-    */
-    private bool on_press(Gdk.EventButton event){
-        //we are now a normal Window, to allow resizing and movement
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.NORMAL;
+     * @name on_press
+     * @description press event captured. The Window should show the popup on right button
+     * @return bool @see widget on_press signal
+     */
+    private bool on_press (Gdk.EventButton event) {
+        // we are now a normal Window, to allow resizing and movement
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.NORMAL;
 
-        //debug("press:%i,%i",(int)event.button,(int)event.y);
+        // debug("press:%i,%i",(int)event.button,(int)event.y);
         if (event.type == Gdk.EventType.BUTTON_PRESS &&
-            (event.button==Gdk.BUTTON_SECONDARY)) {
-            this.show_popup(event);
+            (event.button == Gdk.BUTTON_SECONDARY)) {
+            this.show_popup (event);
             return true;
-        }else if (event.type == Gdk.EventType.BUTTON_PRESS &&
-                 (event.button==Gdk.BUTTON_PRIMARY)) {
-            this.unselect_all();
-            int width = this.get_allocated_width ();
+        } else if (event.type == Gdk.EventType.BUTTON_PRESS &&
+                   (event.button == Gdk.BUTTON_PRIMARY)) {
+            this.unselect_all ();
+            int width  = this.get_allocated_width ();
             int height = this.get_allocated_height ();
-            int margin=30;
-            //debug("x:%d,y:%d,width:%d,height:%d",(int)event.x,(int) event.y,width,height);
-            if(event.x>margin && event.y>margin && event.x<width-margin && event.y<height-margin){
-                this.begin_move_drag((int)event.button,(int) event.x_root,(int) event.y_root, event.time);
+            int margin = 30;
+            // debug("x:%d,y:%d,width:%d,height:%d",(int)event.x,(int) event.y,width,height);
+            if (event.x > margin && event.y > margin && event.x < width - margin && event.y < height - margin) {
+                this.begin_move_drag ((int) event.button, (int) event.x_root, (int) event.y_root, event.time);
             }
 
         }
@@ -253,411 +255,411 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow{
     }
 
     /**
-    * @name show_popup
-    * @description build and show the popup menu
-    * @param event EventButton the origin event, needed to position the menu
-    */
-    private void show_popup(Gdk.EventButton event){
-        //debug("evento:%f,%f",event.x,event.y);
-        //if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
+     * @name show_popup
+     * @description build and show the popup menu
+     * @param event EventButton the origin event, needed to position the menu
+     */
+    private void show_popup (Gdk.EventButton event) {
+        // debug("evento:%f,%f",event.x,event.y);
+        // if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
 
-            //Forcing Dock mode to avoid minimization in certain extremely cases without on_press signal!
-            //TODO exists a way to make resizable and moveable a dock window?
-            this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+        // Forcing Dock mode to avoid minimization in certain extremely cases without on_press signal!
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
 
-            this.menu = new Gtk.Menu ();
+        this.menu      = new Gtk.Menu ();
 
-            // new submenu
-            Gtk.MenuItem item_new = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_SUBMENU);
-            item_new.show();
-            menu.append (item_new);
+        // new submenu
+        Gtk.MenuItem item_new = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_SUBMENU);
+        item_new.show ();
+        menu.append (item_new);
 
-            Gtk.Menu newmenu = new Gtk.Menu ();
-            item_new.set_submenu (newmenu);
+        Gtk.Menu newmenu = new Gtk.Menu ();
+        item_new.set_submenu (newmenu);
 
-            //menu to create a new folder
-            Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_FOLDER);
-            item.activate.connect ((item)=>{
-                    this.new_folder((int)event.x, (int)event.y);
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new folder
+        Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_FOLDER);
+        item.activate.connect ((item) => {
+            this.new_folder ((int) event.x, (int) event.y);
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new empty file
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_EMPTY_FILE);
-            item.activate.connect ((item)=>{
-                    this.new_text_file((int)event.x, (int)event.y);
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new empty file
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_EMPTY_FILE);
+        item.activate.connect ((item) => {
+            this.new_text_file ((int) event.x, (int) event.y);
+        });
+        item.show ();
+        newmenu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show();
-            newmenu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new link file
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_FILE_LINK);
-            item.activate.connect ((item)=>{
-                    this.new_link((int)event.x, (int)event.y,false);
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new link file
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_FILE_LINK);
+        item.activate.connect ((item) => {
+            this.new_link ((int) event.x, (int) event.y, false);
+        });
+        item.show ();
+        newmenu.append (item);
 
-            item = new Gtk.CheckMenuItem.with_label(DesktopFolder.Lang.DESKTOPFOLDER_MENU_ALIGN_TO_GRID);
-            (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings().align_to_grid);
-            (item as Gtk.CheckMenuItem).toggled.connect ((item)=>{
-                this.on_toggle_align_to_grid();
-            });
-            item.show();
-            menu.append (item);
+        item = new Gtk.CheckMenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_ALIGN_TO_GRID);
+        (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings ().align_to_grid);
+        (item as Gtk.CheckMenuItem).toggled.connect ((item) => {
+            this.on_toggle_align_to_grid ();
+        });
+        item.show ();
+        menu.append (item);
 
-            item = new Gtk.CheckMenuItem.with_label(DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_SHADOW);
-            (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings().textshadow);
-            (item as Gtk.CheckMenuItem).toggled.connect ((item)=>{
-                this.on_toggle_shadow();
-            });
-            item.show();
-            menu.append (item);
+        item = new Gtk.CheckMenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_SHADOW);
+        (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings ().textshadow);
+        (item as Gtk.CheckMenuItem).toggled.connect ((item) => {
+            this.on_toggle_shadow ();
+        });
+        item.show ();
+        menu.append (item);
 
-            item = new Gtk.CheckMenuItem.with_label(DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_BOLD);
-            (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings().textbold);
-            (item as Gtk.CheckMenuItem).toggled.connect ((item)=>{
-                this.on_toggle_bold();
-            });
-            item.show();
-            menu.append (item);
+        item = new Gtk.CheckMenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_BOLD);
+        (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings ().textbold);
+        (item as Gtk.CheckMenuItem).toggled.connect ((item) => {
+            this.on_toggle_bold ();
+        });
+        item.show ();
+        menu.append (item);
 
-            //menu to create a new link folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_FOLDER_LINK);
-            item.activate.connect ((item)=>{
-                    this.new_link((int)event.x, (int)event.y,true);
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new link folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_FOLDER_LINK);
+        item.activate.connect ((item) => {
+            this.new_link ((int) event.x, (int) event.y, true);
+        });
+        item.show ();
+        newmenu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show();
-            newmenu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER);
-            item.activate.connect ((item)=>{
-                    this.new_desktop_folder();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER);
+        item.activate.connect ((item) => {
+            this.new_desktop_folder ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new note
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_NOTE);
-            item.activate.connect ((item)=>{
-                    this.new_note();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new note
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_NOTE);
+        item.activate.connect ((item) => {
+            this.new_note ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new photo
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
-            item.activate.connect ((item)=>{
-                    this.new_photo();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new photo
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
+        item.activate.connect ((item) => {
+            this.new_photo ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            item = new MenuItemSeparator();
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
+
+        // option to delete the current folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER);
+        item.activate.connect ((item) => { this.manager.delete (); });
+        item.show ();
+        menu.append (item);
+
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
+
+        // Option to rename the current folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER);
+        item.activate.connect ((item) => { this.rename_folder (); });
+        item.show ();
+        menu.append (item);
+
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
+
+        // If the paste is available, a paste option
+        Clipboard.ClipboardManager cm = Clipboard.ClipboardManager.get_for_display ();
+        if (cm.can_paste) {
+
+            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_PASTE);
+            item.activate.connect ((item) => { this.manager.paste (); });
             item.show ();
             menu.append (item);
 
-            //option to delete the current folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER);
-            item.activate.connect ((item)=>{this.manager.delete();});
+            item = new MenuItemSeparator ();
             item.show ();
             menu.append (item);
+        }
 
-            item = new MenuItemSeparator();
-            item.show ();
-            menu.append (item);
+        // section to change the window head and body colors
+        item = new MenuItemColor (HEAD_TAGS_COLORS);;
+        ((MenuItemColor) item).color_changed.connect (change_head_color);
+        item.show ();
+        menu.append (item);
 
-            //Option to rename the current folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER);
-            item.activate.connect ((item)=>{this.rename_folder();});
-            item.show();
-            menu.append (item);
+        item = new MenuItemColor (BODY_TAGS_COLORS);;
+        ((MenuItemColor) item).color_changed.connect (change_body_color);
+        item.show ();
+        menu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show ();
-            menu.append (item);
+        menu.show_all ();
 
-            //If the paste is available, a paste option
-            Clipboard.ClipboardManager cm=Clipboard.ClipboardManager.get_for_display ();
-            if(cm.can_paste){
+        // }
 
-                item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_PASTE);
-                item.activate.connect ((item)=>{this.manager.paste();});
-                item.show ();
-                menu.append (item);
-
-                item = new MenuItemSeparator();
-                item.show ();
-                menu.append (item);
-            }
-
-            //section to change the window head and body colors
-            item = new MenuItemColor (HEAD_TAGS_COLORS);;
-            ((MenuItemColor)item).color_changed.connect (change_head_color);
-            item.show ();
-            menu.append (item);
-
-            item = new MenuItemColor (BODY_TAGS_COLORS);;
-            ((MenuItemColor)item).color_changed.connect (change_body_color);
-            item.show ();
-            menu.append (item);
-
-            menu.show_all();
-
-        //}
-
-        //finally we show the popup
-        menu.popup(
-             null //parent menu shell
-            ,null //parent menu item
-            ,null //func
-            ,event.button // button
-            ,event.get_time() //Gtk.get_current_event_time() //time
-            );
+        // finally we show the popup
+        menu.popup (
+            null  // parent menu shell
+            , null // parent menu item
+            , null // func
+            , event.button // button
+            , event.get_time () // Gtk.get_current_event_time() //time
+        );
     }
 
     /**
-    * @name on_toggle_bold
-    * @description the bold toggle event. the text bold property must change
-    */
-    private void on_toggle_bold(){
-        Gtk.StyleContext style=this.get_style_context();
-        string bold_class="df_bold";
-        if(this.manager.get_settings().textbold){
-            style.remove_class(bold_class);
-            this.manager.get_settings().textbold=false;
-        }else{
-            style.add_class(bold_class);
-            this.manager.get_settings().textbold=true;
+     * @name on_toggle_bold
+     * @description the bold toggle event. the text bold property must change
+     */
+    private void on_toggle_bold () {
+        Gtk.StyleContext style      = this.get_style_context ();
+        string           bold_class = "df_bold";
+        if (this.manager.get_settings ().textbold) {
+            style.remove_class (bold_class);
+            this.manager.get_settings ().textbold = false;
+        } else {
+            style.add_class (bold_class);
+            this.manager.get_settings ().textbold = true;
         }
-        this.manager.get_settings().save();
-        List<weak Gtk.Widget> children = this.container.get_children();
-        foreach (Gtk.Widget elem in children ) {
-            (elem as ItemView).force_adjust_label();
-        }
-    }
-
-    /**
-    * @name on_toggle_align_to_grid
-    * @description the toggle align to grid event. The align to grid property must change
-    */
-    private void on_toggle_align_to_grid() {
-        if(this.get_sensitivity() == SENSITIVITY_WITH_GRID){
-            this.set_sensitivity(SENSITIVITY_WITHOUT_GRID);
-            this.manager.get_settings().align_to_grid=false;
-        }else{
-            this.set_sensitivity(SENSITIVITY_WITH_GRID);
-            this.manager.get_settings().align_to_grid=true;
-        }
-        this.manager.get_settings().save();
-        this.clear_all();
-        this.manager.sync_files(0,0);
-    }
-
-    /**
-    * @name on_toggle_shadow
-    * @description the toggle shadow event. The shadow property must change
-    */
-    private void on_toggle_shadow() {
-        Gtk.StyleContext style=this.get_style_context();
-        string shadow_class="df_shadow";
-        if(this.manager.get_settings().textshadow){
-            style.remove_class(shadow_class);
-            this.manager.get_settings().textshadow=false;
-        }else{
-            style.add_class(shadow_class);
-            this.manager.get_settings().textshadow=true;
-        }
-        this.manager.get_settings().save();
-        List<weak Gtk.Widget> children = this.container.get_children();
-        foreach (Gtk.Widget elem in children ) {
-            (elem as ItemView).force_adjust_label();
+        this.manager.get_settings ().save ();
+        List<weak Gtk.Widget> children = this.container.get_children ();
+        foreach (Gtk.Widget elem in children) {
+            (elem as ItemView).force_adjust_label ();
         }
     }
 
     /**
-    * @name change_head_color
-    * @description change event captured from the popup for a new color to the head window
-    * @param ncolor int the new color for the head window
-    */
-    private void change_head_color(int ncolor){
-        string color=HEAD_TAGS_COLORS_CLASS[ncolor];
-        for(int i=0;i<HEAD_TAGS_COLORS_CLASS.length;i++){
-            string scolor=HEAD_TAGS_COLORS_CLASS[i];
-            this.get_style_context().remove_class (scolor);
+     * @name on_toggle_align_to_grid
+     * @description the toggle align to grid event. The align to grid property must change
+     */
+    private void on_toggle_align_to_grid () {
+        if (this.get_sensitivity () == SENSITIVITY_WITH_GRID) {
+            this.set_sensitivity (SENSITIVITY_WITHOUT_GRID);
+            this.manager.get_settings ().align_to_grid = false;
+        } else {
+            this.set_sensitivity (SENSITIVITY_WITH_GRID);
+            this.manager.get_settings ().align_to_grid = true;
+        }
+        this.manager.get_settings ().save ();
+        this.clear_all ();
+        this.manager.sync_files (0, 0);
+    }
+
+    /**
+     * @name on_toggle_shadow
+     * @description the toggle shadow event. The shadow property must change
+     */
+    private void on_toggle_shadow () {
+        Gtk.StyleContext style        = this.get_style_context ();
+        string           shadow_class = "df_shadow";
+        if (this.manager.get_settings ().textshadow) {
+            style.remove_class (shadow_class);
+            this.manager.get_settings ().textshadow = false;
+        } else {
+            style.add_class (shadow_class);
+            this.manager.get_settings ().textshadow = true;
+        }
+        this.manager.get_settings ().save ();
+        List<weak Gtk.Widget> children = this.container.get_children ();
+        foreach (Gtk.Widget elem in children) {
+            (elem as ItemView).force_adjust_label ();
+        }
+    }
+
+    /**
+     * @name change_head_color
+     * @description change event captured from the popup for a new color to the head window
+     * @param ncolor int the new color for the head window
+     */
+    private void change_head_color (int ncolor) {
+        string color = HEAD_TAGS_COLORS_CLASS[ncolor];
+        for (int i = 0 ; i < HEAD_TAGS_COLORS_CLASS.length ; i++) {
+            string scolor = HEAD_TAGS_COLORS_CLASS[i];
+            this.get_style_context ().remove_class (scolor);
         }
         this.get_style_context ().add_class (color);
-        this.manager.save_head_color(color);
-        //debug("color:%d,%s",ncolor,color);
+        this.manager.save_head_color (color);
+        // debug("color:%d,%s",ncolor,color);
     }
 
     /**
-    * @name move_item
-    * @description move an item inside this window to a certain position
-    * @param int x the x position
-    * @param int y the y position
-    */
-    public void move_item(ItemView item, int x, int y){
-        this.container.move(item,x,y);
+     * @name move_item
+     * @description move an item inside this window to a certain position
+     * @param int x the x position
+     * @param int y the y position
+     */
+    public void move_item (ItemView item, int x, int y) {
+        this.container.move (item, x, y);
     }
 
     /**
-    * @name change_body_color
-    * @description change event captured from the popup for a new color to the body window
-    * @param ncolor int the new color for the body window
-    */
-    private void change_body_color(int ncolor){
-        string color=BODY_TAGS_COLORS_CLASS[ncolor];
-        for(int i=0;i<BODY_TAGS_COLORS_CLASS.length;i++){
-            string scolor=BODY_TAGS_COLORS_CLASS[i];
-            this.get_style_context().remove_class (scolor);
+     * @name change_body_color
+     * @description change event captured from the popup for a new color to the body window
+     * @param ncolor int the new color for the body window
+     */
+    private void change_body_color (int ncolor) {
+        string color = BODY_TAGS_COLORS_CLASS[ncolor];
+        for (int i = 0 ; i < BODY_TAGS_COLORS_CLASS.length ; i++) {
+            string scolor = BODY_TAGS_COLORS_CLASS[i];
+            this.get_style_context ().remove_class (scolor);
         }
 
-        this.get_style_context().add_class (color);
-        this.manager.save_body_color(color);
-        //debug("color:%d,%s",ncolor,color);
+        this.get_style_context ().add_class (color);
+        this.manager.save_body_color (color);
+        // debug("color:%d,%s",ncolor,color);
     }
 
     /**
-    * @name clear_all
-    * @description clear all the items inside this folder window
-    */
-    public void clear_all(){
-        //debug("clearing all items");
+     * @name clear_all
+     * @description clear all the items inside this folder window
+     */
+    public void clear_all () {
+        // debug("clearing all items");
         var children = this.container.get_children ();
         foreach (Gtk.Widget element in children)
             this.container.remove (element);
     }
 
     /**
-    * @name add_item
-    * @description add an item icon to the container
-    * @param ItemView item the item to be added
-    * @param int x the x position where it should be placed
-    * @param int y the y position where it should be placed
-    */
-    public void add_item(ItemView item, int x, int y){
-        //debug("initial position:%d,%d",x,y);
-        x = ItemView.RoundToNearestMultiple(x, this.get_sensitivity());
-        y = ItemView.RoundToNearestMultiple(y, this.get_sensitivity());
+     * @name add_item
+     * @description add an item icon to the container
+     * @param ItemView item the item to be added
+     * @param int x the x position where it should be placed
+     * @param int y the y position where it should be placed
+     */
+    public void add_item (ItemView item, int x, int y) {
+        // debug("initial position:%d,%d",x,y);
+        x = ItemView.RoundToNearestMultiple (x, this.get_sensitivity ());
+        y = ItemView.RoundToNearestMultiple (y, this.get_sensitivity ());
 
-        this.container.put(item,x,y);
+        this.container.put (item, x, y);
     }
 
     /**
-    * @name raise
-    * @description bring to front the item
-    * @param {ItemView}
-    */
-    public void raise(ItemView item,int x,int y){
-        this.container.remove(item);
-        add_item(item,x,y);
+     * @name raise
+     * @description bring to front the item
+     * @param {ItemView}
+     */
+    public void raise (ItemView item, int x, int y) {
+        this.container.remove (item);
+        add_item (item, x, y);
     }
 
     /**
-    * @name on_key
-    * @description the key event captured for the window
-    * @param EventKey event the event produced
-    * @return bool @see the on_key signal
-    */
-    private bool on_key(Gdk.EventKey event){
-        int key=(int)event.keyval;
-        //debug("event key %d",key);
-        //this is the delete key code
-        const int DELETE_KEY=65535;
-        const int F2_KEY=65471;
-        const int INTRO_KEY=65293;
-        const int ARROW_LEFT_KEY=65361;
-        const int ARROW_UP_KEY=65362;
-        const int ARROW_RIGHT_KEY=65363;
-        const int ARROW_DOWN_KEY=65364;
+     * @name on_key
+     * @description the key event captured for the window
+     * @param EventKey event the event produced
+     * @return bool @see the on_key signal
+     */
+    private bool on_key (Gdk.EventKey event) {
+        int key = (int) event.keyval;
+        // debug("event key %d",key);
+        // this is the delete key code
+        const int DELETE_KEY      = 65535;
+        const int F2_KEY          = 65471;
+        const int INTRO_KEY       = 65293;
+        const int ARROW_LEFT_KEY  = 65361;
+        const int ARROW_UP_KEY    = 65362;
+        const int ARROW_RIGHT_KEY = 65363;
+        const int ARROW_DOWN_KEY  = 65364;
 
-        //check if the control key is pressed
-        var mods = event.state & Gtk.accelerator_get_default_mod_mask ();
+        // check if the control key is pressed
+        var  mods            = event.state & Gtk.accelerator_get_default_mod_mask ();
         bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
 
-        if(event.type==Gdk.EventType.KEY_RELEASE && key==DELETE_KEY){
-            //delete key pressed!
-            ItemView selected=this.get_selected_item();
-            if(selected!=null){
-                selected.delete_dialog();
+        if (event.type == Gdk.EventType.KEY_RELEASE && key == DELETE_KEY) {
+            // delete key pressed!
+            ItemView selected = this.get_selected_item ();
+            if (selected != null) {
+                selected.delete_dialog ();
                 return true;
-            }else{
-                this.manager.delete();
+            } else {
+                this.manager.delete ();
             }
             return false;
-        }else if(event.type==Gdk.EventType.KEY_RELEASE && key==F2_KEY){
-            //ctrl+c key pressed
-            ItemView selected=this.get_selected_item();
-            if(selected!=null){
-                selected.rename_dialog();
+        } else if (event.type == Gdk.EventType.KEY_RELEASE && key == F2_KEY)       {
+            // ctrl+c key pressed
+            ItemView selected = this.get_selected_item ();
+            if (selected != null) {
+                selected.rename_dialog ();
                 return true;
-            }else{
-                this.rename_folder();
+            } else {
+                this.rename_folder ();
             }
             return false;
-        }else if(control_pressed && event.type==Gdk.EventType.KEY_RELEASE && (key=='c' || key=='C')){
-            //ctrl+c key pressed
-            ItemView selected=this.get_selected_item();
-            if(selected!=null) {
-                selected.copy();
-                return true;
-            }
-            return false;
-        }else if(control_pressed && event.type==Gdk.EventType.KEY_RELEASE && (key=='x' || key=='X')){
-            //ctrl+x key pressed
-            ItemView selected=this.get_selected_item();
-            if(selected!=null) {
-                selected.cut();
+        } else if (control_pressed && event.type == Gdk.EventType.KEY_RELEASE && (key == 'c' || key == 'C'))         {
+            // ctrl+c key pressed
+            ItemView selected = this.get_selected_item ();
+            if (selected != null) {
+                selected.copy ();
                 return true;
             }
             return false;
-        }else if(control_pressed && event.type==Gdk.EventType.KEY_RELEASE && (key=='v' || key=='V')){
-            //ctrl+v key pressed
-            this.manager.paste();
-        }else if(event.type==Gdk.EventType.KEY_RELEASE && key==INTRO_KEY){
-            //INTRO key pressed
-            ItemView selected=this.get_selected_item();
-            if(selected!=null) {
-                selected.execute();
+        } else if (control_pressed && event.type == Gdk.EventType.KEY_RELEASE && (key == 'x' || key == 'X'))         {
+            // ctrl+x key pressed
+            ItemView selected = this.get_selected_item ();
+            if (selected != null) {
+                selected.cut ();
                 return true;
             }
-        }else if(event.type==Gdk.EventType.KEY_PRESS && key==ARROW_LEFT_KEY){
-            //left arrow pressed
-            move_selected_to((a,b)=>{
-                return (b.y>=a.y && b.y<=(a.y+a.height)) || (a.y>=b.y && a.y<=(b.y+b.height));
-            },(a,b)=>{
+            return false;
+        } else if (control_pressed && event.type == Gdk.EventType.KEY_RELEASE && (key == 'v' || key == 'V'))         {
+            // ctrl+v key pressed
+            this.manager.paste ();
+        } else if (event.type == Gdk.EventType.KEY_RELEASE && key == INTRO_KEY)       {
+            // INTRO key pressed
+            ItemView selected = this.get_selected_item ();
+            if (selected != null) {
+                selected.execute ();
+                return true;
+            }
+        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_LEFT_KEY)       {
+            // left arrow pressed
+            move_selected_to ((a, b) => {
+                return (b.y >= a.y && b.y <= (a.y + a.height)) || (a.y >= b.y && a.y <= (b.y + b.height));
+            }, (a, b) => {
                 return a.x < b.x;
             });
-        }else if(event.type==Gdk.EventType.KEY_PRESS && key==ARROW_UP_KEY){
-            //up arrow pressed
-            move_selected_to((a,b)=>{
-                return (b.x>=a.x && b.x<=(a.x+a.width)) || (a.x>=b.x && a.x<=(b.x+b.width));
-            },(a,b)=>{
+        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_UP_KEY)       {
+            // up arrow pressed
+            move_selected_to ((a, b) => {
+                return (b.x >= a.x && b.x <= (a.x + a.width)) || (a.x >= b.x && a.x <= (b.x + b.width));
+            }, (a, b) => {
                 return a.y < b.y;
             });
-        }else if(event.type==Gdk.EventType.KEY_PRESS && key==ARROW_RIGHT_KEY){
-            //right arrow pressed
-            move_selected_to((a,b)=>{
-                return (b.y>=a.y && b.y<=(a.y+a.height)) || (a.y>=b.y && a.y<=(b.y+b.height));
-            },(a,b)=>{
+        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_RIGHT_KEY)       {
+            // right arrow pressed
+            move_selected_to ((a, b) => {
+                return (b.y >= a.y && b.y <= (a.y + a.height)) || (a.y >= b.y && a.y <= (b.y + b.height));
+            }, (a, b) => {
                 return a.x > b.x;
             });
-        }else if(event.type==Gdk.EventType.KEY_PRESS && key==ARROW_DOWN_KEY){
-            //down arrow pressed
-            move_selected_to((a,b)=>{
-                return (b.x>=a.x && b.x<=(a.x+a.width)) || (a.x>=b.x && a.x<=(b.x+b.width));
-            },(a,b)=>{
+        } else if (event.type == Gdk.EventType.KEY_PRESS && key == ARROW_DOWN_KEY)       {
+            // down arrow pressed
+            move_selected_to ((a, b) => {
+                return (b.x >= a.x && b.x <= (a.x + a.width)) || (a.x >= b.x && a.x <= (b.x + b.width));
+            }, (a, b) => {
                 return a.y > b.y;
             });
         }
@@ -665,65 +667,65 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow{
     }
 
     /**
-    * @name CompareAllocations
-    * @description Comparator of GtkAllocation objects to order the selection with the keyboard
-    * @return {bool} if the a element is greater than the b element
-    */
-    private delegate bool CompareAllocations(Gtk.Allocation a, Gtk.Allocation b);
+     * @name CompareAllocations
+     * @description Comparator of GtkAllocation objects to order the selection with the keyboard
+     * @return {bool} if the a element is greater than the b element
+     */
+    private delegate bool CompareAllocations (Gtk.Allocation a, Gtk.Allocation b);
 
     /**
-    * @name move_selected_to
-    * @description select the next item following a direction
-    * @param {CompareAllocations} same_axis a function to check that the next item is on the same axis than the previous one
-    * @param {CompareAllocations} is_selectable a function to check that the next item is in the correct direction
-    */
-    private void move_selected_to(CompareAllocations same_axis, CompareAllocations is_selectable){
-        ItemView actual_item = this.get_selected_item();
-        if(actual_item == null){
-            actual_item = (ItemView)this.container.get_children ().nth_data(0);
-            if(actual_item == null){
-                debug("There is not widgets on the folder.");
+     * @name move_selected_to
+     * @description select the next item following a direction
+     * @param {CompareAllocations} same_axis a function to check that the next item is on the same axis than the previous one
+     * @param {CompareAllocations} is_selectable a function to check that the next item is in the correct direction
+     */
+    private void move_selected_to (CompareAllocations same_axis, CompareAllocations is_selectable) {
+        ItemView actual_item = this.get_selected_item ();
+        if (actual_item == null) {
+            actual_item = (ItemView) this.container.get_children ().nth_data (0);
+            if (actual_item == null) {
+                debug ("There is not widgets on the folder.");
                 return;
             }
         }
         Gtk.Allocation actual_allocation;
-        actual_item.get_allocation(out actual_allocation);
-        ItemView next_item = null;
-        Gtk.Allocation next_allocation=actual_allocation;
+        actual_item.get_allocation (out actual_allocation);
+        ItemView       next_item       = null;
+        Gtk.Allocation next_allocation = actual_allocation;
 
-        List<weak Gtk.Widget> children = this.container.get_children();
-        foreach (Gtk.Widget elem in children ) {
+        List<weak Gtk.Widget> children = this.container.get_children ();
+        foreach (Gtk.Widget elem in children) {
             Gtk.Allocation elem_allocation;
-            elem.get_allocation(out elem_allocation);
-            if(same_axis(elem_allocation,actual_allocation) && is_selectable(elem_allocation,actual_allocation)){
-                if(next_item==null){
-                    //If this is the first element is selectable found
-                    next_allocation=elem_allocation;
-                    next_item=(ItemView)elem;
-                }else if (!is_selectable(elem_allocation,next_allocation)) {
-                    //If it is nearer from the last found
-                    next_allocation=elem_allocation;
-                    next_item=(ItemView)elem;
+            elem.get_allocation (out elem_allocation);
+            if (same_axis (elem_allocation, actual_allocation) && is_selectable (elem_allocation, actual_allocation)) {
+                if (next_item == null) {
+                    // If this is the first element is selectable found
+                    next_allocation = elem_allocation;
+                    next_item       = (ItemView) elem;
+                } else if (!is_selectable (elem_allocation, next_allocation))    {
+                    // If it is nearer from the last found
+                    next_allocation = elem_allocation;
+                    next_item       = (ItemView) elem;
                 }
             }
         }
-        if(next_item!=null){
-            next_item.select();
-        }else {
-            debug("There are no elements on this direction");
+        if (next_item != null) {
+            next_item.select ();
+        } else {
+            debug ("There are no elements on this direction");
         }
     }
 
     /**
-    * @name get_selected_item
-    * @description return the selected item
-    * @return ItemView return the selected item at the desktop folder, or null if none selected
-    */
-    private ItemView get_selected_item(){
+     * @name get_selected_item
+     * @description return the selected item
+     * @return ItemView return the selected item at the desktop folder, or null if none selected
+     */
+    private ItemView get_selected_item () {
         var children = this.container.get_children ();
-        for(int i=0;i<children.length();i++){
-            ItemView element=(ItemView) children.nth_data(i);
-            if(element.is_selected()){
+        for (int i = 0 ; i < children.length () ; i++) {
+            ItemView element = (ItemView) children.nth_data (i);
+            if (element.is_selected ()) {
                 return element;
             }
         }
@@ -731,187 +733,188 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow{
     }
 
     /**
-    * @name new_desktop_folder
-    * @description show a dialog to create a new desktop folder
-    */
-    private void new_desktop_folder(){
-        DesktopFolder.Util.create_new_desktop_folder(this);
+     * @name new_desktop_folder
+     * @description show a dialog to create a new desktop folder
+     */
+    private void new_desktop_folder () {
+        DesktopFolder.Util.create_new_desktop_folder (this);
     }
 
     /**
-    * @name new_note
-    * @description show a dialog to create a new note
-    */
-    private void new_note(){
-        DesktopFolder.Util.create_new_note(this);
+     * @name new_note
+     * @description show a dialog to create a new note
+     */
+    private void new_note () {
+        DesktopFolder.Util.create_new_note (this);
     }
 
     /**
-    * @name new_photo
-    * @description show a dialog to create a new photo
-    */
-    private void new_photo(){
-        DesktopFolder.Util.create_new_photo(this);
+     * @name new_photo
+     * @description show a dialog to create a new photo
+     */
+    private void new_photo () {
+        DesktopFolder.Util.create_new_photo (this);
     }
 
     /**
-    * @name new_folder
-    * @description show a dialog to create a new folder
-    * @param int x the x position where the new folder icon should be generated
-    * @param int y the y position where the new folder icon should be generated
-    */
-    private void new_folder(int x, int y){
+     * @name new_folder
+     * @description show a dialog to create a new folder
+     * @param int x the x position where the new folder icon should be generated
+     * @param int y the y position where the new folder icon should be generated
+     */
+    private void new_folder (int x, int y) {
         RenameDialog dialog = new RenameDialog (this,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_TITLE,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_MESSAGE,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_NAME);
-        dialog.on_rename.connect((new_name)=>{
-            //creating the folder
-            if(new_name!=""){
-                this.manager.create_new_folder(new_name,x, y);
+        dialog.on_rename.connect ((new_name) => {
+            // creating the folder
+            if (new_name != "") {
+                this.manager.create_new_folder (new_name, x, y);
             }
         });
         dialog.show_all ();
     }
 
     /**
-    * @name new_text_file
-    * @description create a new text file item inside this folder
-    * @param int x the x position where the new item should be placed
-    * @param int y the y position where the new item should be placed
-    */
-    private void new_text_file(int x, int y){
+     * @name new_text_file
+     * @description create a new text file item inside this folder
+     * @param int x the x position where the new item should be placed
+     * @param int y the y position where the new item should be placed
+     */
+    private void new_text_file (int x, int y) {
         RenameDialog dialog = new RenameDialog (this,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_TITLE,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_MESSAGE,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_NAME);
-        dialog.on_rename.connect((new_name)=>{
-            if(new_name!=""){
-                this.manager.create_new_text_file(new_name, x, y);
+        dialog.on_rename.connect ((new_name) => {
+            if (new_name != "") {
+                this.manager.create_new_text_file (new_name, x, y);
             }
         });
         dialog.show_all ();
     }
 
     /**
-    * @name new_link
-    * @description create a new linnk item inside this folder
-    * @param int x the x position where the new item should be placed
-    * @param int y the y position where the new item should be placed
-    * @param bool folder to indicate if we want to select a folder or a file
-    */
-    private void new_link(int x, int y, bool folder){
+     * @name new_link
+     * @description create a new linnk item inside this folder
+     * @param int x the x position where the new item should be placed
+     * @param int y the y position where the new item should be placed
+     * @param bool folder to indicate if we want to select a folder or a file
+     */
+    private void new_link (int x, int y, bool folder) {
         Gtk.FileChooserDialog chooser = new Gtk.FileChooserDialog (
-				DesktopFolder.Lang.DESKTOPFOLDER_LINK_MESSAGE, this, Gtk.FileChooserAction.OPEN,
-				DesktopFolder.Lang.DIALOG_CANCEL,
-				Gtk.ResponseType.CANCEL,
-				DesktopFolder.Lang.DIALOG_SELECT,
-				Gtk.ResponseType.ACCEPT);
+            DesktopFolder.Lang.DESKTOPFOLDER_LINK_MESSAGE, this, Gtk.FileChooserAction.OPEN,
+            DesktopFolder.Lang.DIALOG_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            DesktopFolder.Lang.DIALOG_SELECT,
+            Gtk.ResponseType.ACCEPT);
 
-        if(folder){
-            chooser.set_action(Gtk.FileChooserAction.SELECT_FOLDER);
+        if (folder) {
+            chooser.set_action (Gtk.FileChooserAction.SELECT_FOLDER);
         }
         // Process response:
-		if (chooser.run () == Gtk.ResponseType.ACCEPT) {
-            var filename=chooser.get_filename();
-            debug("file:%s",filename);
-            this.manager.create_new_link(filename, x, y);
-		}
-        chooser.close();
+        if (chooser.run () == Gtk.ResponseType.ACCEPT) {
+            var filename = chooser.get_filename ();
+            debug ("file:%s", filename);
+            this.manager.create_new_link (filename, x, y);
+        }
+        chooser.close ();
     }
 
     /**
-    * @name rename_folder
-    * @description try to rename the current desktop folder
-    */
-    private void rename_folder(){
+     * @name rename_folder
+     * @description try to rename the current desktop folder
+     */
+    private void rename_folder () {
         RenameDialog dialog = new RenameDialog (this,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER,
                                                 DesktopFolder.Lang.DESKTOPFOLDER_RENAME_MESSAGE,
-                                                this.manager.get_folder_name());
-        dialog.on_rename.connect((new_name)=>{
-            if(this.manager.rename(new_name)){
-                this.set_title(new_name);
+                                                this.manager.get_folder_name ());
+        dialog.on_rename.connect ((new_name) => {
+            if (this.manager.rename (new_name)) {
+                this.set_title (new_name);
             }
         });
         dialog.show_all ();
     }
 
     /**
-    * @name unselect_all
-    * @description unselect all the items inside this folder
-    */
-    public void unselect_all(){
+     * @name unselect_all
+     * @description unselect all the items inside this folder
+     */
+    public void unselect_all () {
         var children = this.container.get_children ();
-        foreach (Gtk.Widget element in children){
-            ((ItemView)element).unselect();
+        foreach (Gtk.Widget element in children) {
+            ((ItemView) element).unselect ();
         }
     }
 
     /**
-    * @name get_sensitivity
-    * @description Get the value of sensitivity, used to calculate the alignment of the items
-    */
-    public int get_sensitivity(){
+     * @name get_sensitivity
+     * @description Get the value of sensitivity, used to calculate the alignment of the items
+     */
+    public int get_sensitivity () {
         return this.sensitivity;
     }
 
     /**
-    * @name set_sensitivity
-    * @description Set value to sensitivity, used to calculate the alignment of the items
-    */
-    public void set_sensitivity(int s){
-        this.sensitivity=s;
+     * @name set_sensitivity
+     * @description Set value to sensitivity, used to calculate the alignment of the items
+     */
+    public void set_sensitivity (int s) {
+        this.sensitivity = s;
     }
 
     /**
-    * @name on_item_moving
-    * @description event capture of an item moving or stop moving
-    * @param {bool} moving if the item started moving or stopped moving
-    */
-    public void on_item_moving(bool moving){
-        this.flag_moving=moving;
-        this.queue_draw();
+     * @name on_item_moving
+     * @description event capture of an item moving or stop moving
+     * @param {bool} moving if the item started moving or stopped moving
+     */
+    public void on_item_moving (bool moving) {
+        this.flag_moving = moving;
+        this.queue_draw ();
     }
 
     /**
-    * @name draw_backgorund
-    * @description draw the note window background intercepting the draw signal
-    * @param {Cairo.Context} cr the cairo context
-    * @bool @see draw signal
-    */
+     * @name draw_backgorund
+     * @description draw the note window background intercepting the draw signal
+     * @param {Cairo.Context} cr the cairo context
+     * @bool @see draw signal
+     */
     private bool draw_background (Cairo.Context cr) {
 
-        //we must show the grid if it is enabled and an item being moved
-        if(flag_moving==true && this.manager.get_settings().align_to_grid){
-            int width = this.get_allocated_width ();
+        // we must show the grid if it is enabled and an item being moved
+        if (flag_moving == true && this.manager.get_settings ().align_to_grid) {
+            int width  = this.get_allocated_width ();
             int height = this.get_allocated_height ();
 
             cr.set_operator (Cairo.Operator.CLEAR);
             cr.paint ();
             cr.set_operator (Cairo.Operator.OVER);
 
-            cr.rectangle (0, 40, width-14, height-54);
+            cr.rectangle (0, 40, width - 14, height - 54);
             cr.clip ();
 
-            int padding=13;
-            int paddingx2=padding*2;
-            int header=35;
-            int margin=10;
-            int sensitivity=SENSITIVITY_WITH_GRID-10;
+            int padding     = 13;
+            int paddingx2   = padding * 2;
+            int header      = 35;
+            int margin      = 10;
+            int sensitivity = SENSITIVITY_WITH_GRID - 10;
             cr.set_source_rgba (1, 1, 1, 0.3);
-            for(int i=padding;i<width-paddingx2;i=i+sensitivity+margin){
-                for(int j=padding+header;j<height-paddingx2;j=j+sensitivity+margin){
+            for (int i = padding ; i < width - paddingx2 ; i = i + sensitivity + margin) {
+                for (int j = padding + header ; j < height - paddingx2 ; j = j + sensitivity + margin) {
                     cr.rectangle (i, j, sensitivity, sensitivity);
-    	            cr.fill ();
+                    cr.fill ();
                 }
             }
 
-            cr.reset_clip();
+            cr.reset_clip ();
         }
 
         base.draw (cr);
 
         return true;
     }
+
 }

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -561,6 +561,14 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
     public void copy () {
         this.manager.copy ();
     }
+    
+    /**
+     * @name copy
+     * @description copy the file to the clipboard
+     */
+    public void trash () {
+        this.manager.trash ();
+    }
 
     /**
      * @name delete_dialog

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -522,7 +522,7 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         menu.append (item);
 
         item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_DELETE);
-        item.activate.connect ((item) => { this.delete_dialog (); });
+        item.activate.connect ((item) => { this.manager.trash (); });
         item.show ();
         menu.append (item);
 
@@ -585,10 +585,10 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
             case Gtk.ResponseType.OK:
                 msg.destroy ();
                 if (isdir) {
-                    this.manager.delete ();
+                    this.manager.trash ();
                     break;
                 } else {
-                    this.manager.delete ();
+                    this.manager.trash ();
                 }
                 break;
             default:

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -1,49 +1,49 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 public class DesktopFolder.ItemView : Gtk.EventBox {
 
-    //NOT SURE ABOUT THESE CONSTANTS!!! TODO!!!!!
-    public const int PADDING_X=13;
-    public const int PADDING_Y=47;
-    //DEFAULT SIZES
-    private const int DEFAULT_WIDTH=48;
-    private const int DEFAULT_HEIGHT=68;
-    private const int MAX_CHARACTERS=13;
+    // NOT SURE ABOUT THESE CONSTANTS!!! TODO!!!!!
+    public const int PADDING_X       = 13;
+    public const int PADDING_Y       = 47;
+    // DEFAULT SIZES
+    private const int DEFAULT_WIDTH  = 48;
+    private const int DEFAULT_HEIGHT = 68;
+    private const int MAX_CHARACTERS = 13;
     /** flag to know that the item has been moved */
-    private bool flagModified=false;
-    private bool flagMoved=false;
+    private bool flagModified        = false;
+    private bool flagMoved           = false;
     /** the manager of this item icon */
     private ItemManager manager;
     /** the context menu for this item */
-    private Gtk.Menu menu=null;
+    private Gtk.Menu menu = null;
 
     /** flag to know if we should hide the extension of the file */
-    private bool hide_extension=false;
+    private bool hide_extension     = false;
     /** the hidden extension of the file, it it was hidden, @see hide_extension*/
-    private string hidden_extension="";
+    private string hidden_extension = "";
 
     /** the container of this item view */
     private Gtk.Box container;
     /** the label of the icon */
     private Gtk.Label label;
     /** the image shown */
-    private Gtk.Image icon=null;
+    private Gtk.Image icon = null;
 
     /** set of variables to allow move the widget */
     private int offsetx;
@@ -54,360 +54,360 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
     private int maxy;
     /** ----------------------------------------- */
 
-    //this is the link image loaded
-    static Gdk.Pixbuf LINK_PIXBUF=null;
+    // this is the link image loaded
+    static Gdk.Pixbuf LINK_PIXBUF = null;
     static construct {
-        try{
-            int scale=DesktopFolder.ICON_SIZE/3;
-            ItemView.LINK_PIXBUF=new Gdk.Pixbuf.from_resource("/com/github/spheras/desktopfolder/link.svg");
-            ItemView.LINK_PIXBUF=LINK_PIXBUF.scale_simple(scale,scale,Gdk.InterpType.BILINEAR);
-        }catch (Error e) {
+        try {
+            int scale = DesktopFolder.ICON_SIZE / 3;
+            ItemView.LINK_PIXBUF = new Gdk.Pixbuf.from_resource ("/com/github/spheras/desktopfolder/link.svg");
+            ItemView.LINK_PIXBUF = LINK_PIXBUF.scale_simple (scale, scale, Gdk.InterpType.BILINEAR);
+        } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @constructor
-    * @param ItemManager manager the manager of this item view
-    */
-    public ItemView(ItemManager manager){
-        this.manager=manager;
+     * @constructor
+     * @param ItemManager manager the manager of this item view
+     */
+    public ItemView (ItemManager manager) {
+        this.manager = manager;
 
-        //we set the default size
-        this.set_size_request(DEFAULT_WIDTH,DEFAULT_HEIGHT);
-        //class for this widget
+        // we set the default size
+        this.set_size_request (DEFAULT_WIDTH, DEFAULT_HEIGHT);
+        // class for this widget
         this.get_style_context ().add_class ("df_item");
 
-        //we connect the enter and leave events
+        // we connect the enter and leave events
         this.enter_notify_event.connect (this.on_enter);
-        this.leave_notify_event.connect(this.on_leave);
-        this.button_press_event.connect(this.on_press);
-        this.button_release_event.connect(this.on_release);
-        this.motion_notify_event.connect(this.on_motion);
+        this.leave_notify_event.connect (this.on_leave);
+        this.button_press_event.connect (this.on_press);
+        this.button_release_event.connect (this.on_release);
+        this.motion_notify_event.connect (this.on_motion);
 
-        //we create the components to put inside the item (icon and label)
-        this.container=new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-        this.container.margin=0;
-        this.container.set_size_request(DEFAULT_WIDTH,DEFAULT_HEIGHT);
+        // we create the components to put inside the item (icon and label)
+        this.container        = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        this.container.margin = 0;
+        this.container.set_size_request (DEFAULT_WIDTH, DEFAULT_HEIGHT);
 
-        try{
-            this.refresh_icon();
-            string slabel=this.get_correct_label(this.manager.get_file_name());
-            this.label=new Gtk.Label (slabel);
-            this.label.set_width_chars(MAX_CHARACTERS);
-            this.label.set_max_width_chars(MAX_CHARACTERS);
-            this.label.wrap_mode=Pango.WrapMode.WORD_CHAR;
-            this.label.set_line_wrap(true);
-            this.label.set_justify(Gtk.Justification.CENTER);
+        try {
+            this.refresh_icon ();
+            string slabel = this.get_correct_label (this.manager.get_file_name ());
+            this.label = new Gtk.Label (slabel);
+            this.label.set_width_chars (MAX_CHARACTERS);
+            this.label.set_max_width_chars (MAX_CHARACTERS);
+            this.label.wrap_mode = Pango.WrapMode.WORD_CHAR;
+            this.label.set_line_wrap (true);
+            this.label.set_justify (Gtk.Justification.CENTER);
 
             this.label.get_style_context ().add_class ("df_label");
-            this.check_ellipse(slabel);
-            this.container.pack_end(label,true,true);
-        }catch (Error e) {
+            this.check_ellipse (slabel);
+            this.container.pack_end (label, true, true);
+        } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
 
-        this.add(this.container);
+        this.add (this.container);
     }
 
     /**
-    * @name refresh_icon
-    * @description force to refresh the icon imagen shown
-    */
-    public void refresh_icon(){
-        Gtk.Image newImage=this.calculate_icon();
-        if(this.icon!=null){
+     * @name refresh_icon
+     * @description force to refresh the icon imagen shown
+     */
+    public void refresh_icon () {
+        Gtk.Image newImage = this.calculate_icon ();
+        if (this.icon != null) {
             this.container.remove (this.icon);
         }
-        this.icon=newImage;
-        this.icon.set_size_request(DEFAULT_WIDTH,DEFAULT_HEIGHT);
+        this.icon = newImage;
+        this.icon.set_size_request (DEFAULT_WIDTH, DEFAULT_HEIGHT);
         this.icon.get_style_context ().add_class ("df_icon");
-        this.container.pack_start(this.icon,true,true);
-        this.show_all();
+        this.container.pack_start (this.icon, true, true);
+        this.show_all ();
     }
 
     /**
-    * @name calculate_icon
-    * @description calculate the icon image to show
-    * @return Gtk.Image the image to be shown
-    */
-    private Gtk.Image calculate_icon(){
+     * @name calculate_icon
+     * @description calculate the icon image to show
+     * @return Gtk.Image the image to be shown
+     */
+    private Gtk.Image calculate_icon () {
         try {
             Gtk.Image icon;
-            var fileInfo=this.manager.get_file().query_info("standard::icon",FileQueryInfoFlags.NONE);
-            if(manager.get_settings().icon!=null && manager.get_settings().icon.length>0){
-                //we have a custom icon
-                int scale=DesktopFolder.ICON_SIZE;
-                Gdk.Pixbuf custom=new Gdk.Pixbuf.from_file(manager.get_settings().icon);
-                custom=custom.scale_simple(scale,scale,Gdk.InterpType.BILINEAR);
-                if(this.manager.is_link()){
-                    icon=this.draw_link_mark_pixbuf(custom);
-                }else{
-                    icon=new Gtk.Image.from_pixbuf(custom);
+            var       fileInfo = this.manager.get_file ().query_info ("standard::icon", FileQueryInfoFlags.NONE);
+            if (manager.get_settings ().icon != null && manager.get_settings ().icon.length > 0) {
+                // we have a custom icon
+                int        scale  = DesktopFolder.ICON_SIZE;
+                Gdk.Pixbuf custom = new Gdk.Pixbuf.from_file (manager.get_settings ().icon);
+                custom = custom.scale_simple (scale, scale, Gdk.InterpType.BILINEAR);
+                if (this.manager.is_link ()) {
+                    icon = this.draw_link_mark_pixbuf (custom);
+                } else {
+                    icon = new Gtk.Image.from_pixbuf (custom);
                 }
-            }else{
-                if(this.manager.is_desktop_file()){
-                    GLib.DesktopAppInfo desktopApp=new GLib.DesktopAppInfo.from_filename(this.manager.get_absolute_path());
-                    GLib.Icon gicon=desktopApp.get_icon();
-                    if(this.manager.is_link()){
-                        icon=this.draw_link_mark_gicon(gicon);
-                    }else{
-                        icon=new Gtk.Image.from_gicon(gicon,Gtk.IconSize.DIALOG);
+            } else {
+                if (this.manager.is_desktop_file ()) {
+                    GLib.DesktopAppInfo desktopApp = new GLib.DesktopAppInfo.from_filename (this.manager.get_absolute_path ());
+                    GLib.Icon           gicon      = desktopApp.get_icon ();
+                    if (this.manager.is_link ()) {
+                        icon = this.draw_link_mark_gicon (gicon);
+                    } else {
+                        icon = new Gtk.Image.from_gicon (gicon, Gtk.IconSize.DIALOG);
                     }
-                }else{
+                } else {
 
-                    var ctypeInfo = this.manager.get_file().query_info("standard::content-type", FileQueryInfoFlags.NONE);
-                    string contentType=ctypeInfo.get_content_type();
-                    string mimeType=GLib.ContentType.get_mime_type(contentType);
-                    var isImage=GLib.ContentType.is_a(mimeType,"image/*");
-                    if(mimeType!=null && isImage){
-                        //reading the image to show it
-                        int scale=DesktopFolder.ICON_SIZE;
-                        Gdk.Pixbuf custom=new Gdk.Pixbuf.from_file(this.manager.get_file().get_path());
-                        custom=custom.scale_simple(scale,scale,Gdk.InterpType.BILINEAR);
-                        if(this.manager.is_link()){
-                            icon=this.draw_link_mark_pixbuf(custom);
-                        }else{
-                            icon=new Gtk.Image.from_pixbuf(custom);
+                    var    ctypeInfo   = this.manager.get_file ().query_info ("standard::content-type", FileQueryInfoFlags.NONE);
+                    string contentType = ctypeInfo.get_content_type ();
+                    string mimeType    = GLib.ContentType.get_mime_type (contentType);
+                    var    isImage     = GLib.ContentType.is_a (mimeType, "image/*");
+                    if (mimeType != null && isImage) {
+                        // reading the image to show it
+                        int        scale  = DesktopFolder.ICON_SIZE;
+                        Gdk.Pixbuf custom = new Gdk.Pixbuf.from_file (this.manager.get_file ().get_path ());
+                        custom = custom.scale_simple (scale, scale, Gdk.InterpType.BILINEAR);
+                        if (this.manager.is_link ()) {
+                            icon = this.draw_link_mark_pixbuf (custom);
+                        } else {
+                            icon = new Gtk.Image.from_pixbuf (custom);
                         }
-                    }else{
-                        //we get the default icon from the system
-                        GLib.Icon gicon=fileInfo.get_icon();
-                        if(this.manager.is_link()){
-                            icon=this.draw_link_mark_gicon(gicon);
-                        }else{
-                            icon=new Gtk.Image.from_gicon(gicon,Gtk.IconSize.DIALOG);
+                    } else {
+                        // we get the default icon from the system
+                        GLib.Icon gicon = fileInfo.get_icon ();
+                        if (this.manager.is_link ()) {
+                            icon = this.draw_link_mark_gicon (gicon);
+                        } else {
+                            icon = new Gtk.Image.from_gicon (gicon, Gtk.IconSize.DIALOG);
                         }
                     }
                 }
             }
             return icon;
-        }catch (Error e) {
-            stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
-        }
-        return null as Gtk.Image;
-    }
-
-    /**
-    * @name draw_link_mark_gicon
-    * @description draw a link mark over the image of an icon
-    * @param gicon {GLib.Icon} the icon we want to modify and add the mark
-    * @result {Gtk.Image} the image produced
-    */
-    private Gtk.Image draw_link_mark_gicon(GLib.Icon gicon){
-        try{
-            Gtk.IconTheme theme=Gtk.IconTheme.get_default();
-            Gtk.IconInfo iconInfo=theme.lookup_by_gicon(gicon, ICON_SIZE,0);
-            Gdk.Pixbuf pixbuf=iconInfo.load_icon();
-            return this.draw_link_mark_pixbuf(pixbuf);
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
         return null as Gtk.Image;
     }
 
     /**
-    * @name draw_link_mark_pixbuf
-    * @description draw a link mark over a pixbuf
-    * @param pixbuf {Gdk.Pixbuf} the pixbuf to modify
-    * @result {Gtk.Image} the image produced
-    */
-    private Gtk.Image draw_link_mark_pixbuf(Gdk.Pixbuf pixbuf){
-        try{
-            var surface=Gdk.cairo_surface_create_from_pixbuf(pixbuf,1,null);
+     * @name draw_link_mark_gicon
+     * @description draw a link mark over the image of an icon
+     * @param gicon {GLib.Icon} the icon we want to modify and add the mark
+     * @result {Gtk.Image} the image produced
+     */
+    private Gtk.Image draw_link_mark_gicon (GLib.Icon gicon) {
+        try {
+            Gtk.IconTheme theme    = Gtk.IconTheme.get_default ();
+            Gtk.IconInfo  iconInfo = theme.lookup_by_gicon (gicon, ICON_SIZE, 0);
+            Gdk.Pixbuf    pixbuf   = iconInfo.load_icon ();
+            return this.draw_link_mark_pixbuf (pixbuf);
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            Util.show_error_dialog ("Error", e.message);
+        }
+        return null as Gtk.Image;
+    }
+
+    /**
+     * @name draw_link_mark_pixbuf
+     * @description draw a link mark over a pixbuf
+     * @param pixbuf {Gdk.Pixbuf} the pixbuf to modify
+     * @result {Gtk.Image} the image produced
+     */
+    private Gtk.Image draw_link_mark_pixbuf (Gdk.Pixbuf pixbuf) {
+        try {
+            var surface = Gdk.cairo_surface_create_from_pixbuf (pixbuf, 1, null);
             var context = new Cairo.Context (surface);
 
-            int scale=DesktopFolder.ICON_SIZE/3;
-            var links=Gdk.cairo_surface_create_from_pixbuf(ItemView.LINK_PIXBUF, 1, null);
-            context.set_source_surface (links, ICON_SIZE-scale, ICON_SIZE-scale);
-            context.paint();
+            int scale   = DesktopFolder.ICON_SIZE / 3;
+            var links   = Gdk.cairo_surface_create_from_pixbuf (ItemView.LINK_PIXBUF, 1, null);
+            context.set_source_surface (links, ICON_SIZE - scale, ICON_SIZE - scale);
+            context.paint ();
 
-            var pixbuf2=Gdk.pixbuf_get_from_surface(surface,0,0,ICON_SIZE,ICON_SIZE);
-            Gtk.Image icon=new Gtk.Image.from_pixbuf(pixbuf2);
+            var       pixbuf2 = Gdk.pixbuf_get_from_surface (surface, 0, 0, ICON_SIZE, ICON_SIZE);
+            Gtk.Image icon    = new Gtk.Image.from_pixbuf (pixbuf2);
             return icon;
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog("Error",e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
     /**
-    * @name get_correct_label
-    * @description return the correct label to be shown
-    */
-    private string get_correct_label(string file_name){
-        if(this.hide_extension){
-            int index=file_name.index_of(".",0);
-            if(index>0){
-                hidden_extension=file_name.substring(index);
-                return file_name.substring(0,index);
+     * @name get_correct_label
+     * @description return the correct label to be shown
+     */
+    private string get_correct_label (string file_name) {
+        if (this.hide_extension) {
+            int index = file_name.index_of (".", 0);
+            if (index > 0) {
+                hidden_extension = file_name.substring (index);
+                return file_name.substring (0, index);
             }
-            hidden_extension="";
+            hidden_extension = "";
             return file_name;
-        }else{
-            int index=file_name.index_of(".desktop",0);
-            if(index>0){
-                //is a desktop file!
-                this.hide_extension=true;
-                hidden_extension=file_name.substring(index);
-                return file_name.substring(0,index);
+        } else {
+            int index = file_name.index_of (".desktop", 0);
+            if (index > 0) {
+                // is a desktop file!
+                this.hide_extension = true;
+                hidden_extension    = file_name.substring (index);
+                return file_name.substring (0, index);
             }
-            hidden_extension="";
+            hidden_extension = "";
             return file_name;
         }
     }
 
     /**
-    * @name check_ellipse
-    * @description check if the ellipse should be shown
-    * @param string name the name to be shown in order to calculate if the ellipse will be shown
-    */
-    private void check_ellipse(string name){
-        if(name.length>MAX_CHARACTERS){
-            this.label.set_lines(2);
-            this.label.set_ellipsize(Pango.EllipsizeMode.END);
-        }else{
-            this.label.set_lines(1);
-            this.label.set_ellipsize(Pango.EllipsizeMode.NONE);
+     * @name check_ellipse
+     * @description check if the ellipse should be shown
+     * @param string name the name to be shown in order to calculate if the ellipse will be shown
+     */
+    private void check_ellipse (string name) {
+        if (name.length > MAX_CHARACTERS) {
+            this.label.set_lines (2);
+            this.label.set_ellipsize (Pango.EllipsizeMode.END);
+        } else {
+            this.label.set_lines (1);
+            this.label.set_ellipsize (Pango.EllipsizeMode.NONE);
         }
     }
 
     /**
-    * @name on_enter
-    * @description on_enter signal to highlight the icon
-    * @param eventCrossing EventCrossing @see on_enter signal
-    * @return bool @see the on_enter signal
-    */
-    private bool on_enter(Gdk.EventCrossing eventCrossing){
+     * @name on_enter
+     * @description on_enter signal to highlight the icon
+     * @param eventCrossing EventCrossing @see on_enter signal
+     * @return bool @see the on_enter signal
+     */
+    private bool on_enter (Gdk.EventCrossing eventCrossing) {
         this.get_style_context ().add_class ("df_item_over");
-        //debug("enter item");
+        // debug("enter item");
         return true;
     }
 
     /**
-    * @name on_leave
-    * @description on_leave signal to remove highlight of the icon
-    * @param eventCrossing EventCrossing @see on_enter signal
-    * @return bool @see the on_leave signal
-    */
-    private bool on_leave(Gdk.EventCrossing eventCrossing){
-        //we remove the highlight class
+     * @name on_leave
+     * @description on_leave signal to remove highlight of the icon
+     * @param eventCrossing EventCrossing @see on_enter signal
+     * @return bool @see the on_leave signal
+     */
+    private bool on_leave (Gdk.EventCrossing eventCrossing) {
+        // we remove the highlight class
         this.get_style_context ().remove_class ("df_item_over");
 
-        if(this.flagModified){
+        if (this.flagModified) {
             Gtk.Allocation allocation;
-            this.get_allocation(out allocation);
-             //HELP! don't know why these constants?? maybe padding??
-            int x=allocation.x - PADDING_X;
-            int y=allocation.y - PADDING_Y;
+            this.get_allocation (out allocation);
+            // HELP! don't know why these constants?? maybe padding??
+            int x = allocation.x - PADDING_X;
+            int y = allocation.y - PADDING_Y;
 
-            this.manager.save_position(x,y);
-            this.flagModified=false;
+            this.manager.save_position (x, y);
+            this.flagModified = false;
         }
-        //debug("leave item");
+        // debug("leave item");
         return true;
     }
 
     /**
-    * @name rename
-    * @description action of rename the item selected by the user
-    * @param string new_name the new name for this item
-    */
-    public void rename(string new_name){
-        debug("renaming to:%s",new_name+this.hidden_extension);
-        if(this.manager.rename(new_name+this.hidden_extension)){
-            this.label.set_label(new_name);
-            this.check_ellipse(new_name);
+     * @name rename
+     * @description action of rename the item selected by the user
+     * @param string new_name the new name for this item
+     */
+    public void rename (string new_name) {
+        debug ("renaming to:%s", new_name + this.hidden_extension);
+        if (this.manager.rename (new_name + this.hidden_extension)) {
+            this.label.set_label (new_name);
+            this.check_ellipse (new_name);
         }
     }
 
     /**
-    * @name force_adjust_label
-    * @description util function to foce the label to readjust
-    * sometimes, the label change its appareance, but it is not adjusted automatically
-    * this function force the adjust
-    */
-    public void force_adjust_label(){
-        this.label.set_label(this.label.get_text());
+     * @name force_adjust_label
+     * @description util function to foce the label to readjust
+     * sometimes, the label change its appareance, but it is not adjusted automatically
+     * this function force the adjust
+     */
+    public void force_adjust_label () {
+        this.label.set_label (this.label.get_text ());
     }
 
     /**
-    * @name select
-    * @description the user select the icon
-    */
-    public void select(){
-        Gtk.Window window=(Gtk.Window) this.get_toplevel();
-        ((FolderWindow)window).unselect_all();
-        this.manager.select();
+     * @name select
+     * @description the user select the icon
+     */
+    public void select () {
+        Gtk.Window window = (Gtk.Window) this.get_toplevel ();
+        ((FolderWindow) window).unselect_all ();
+        this.manager.select ();
         this.get_style_context ().add_class ("df_selected");
     }
 
     /**
-    * @name unselect
-    * @description unselect the icon
-    */
-    public void unselect(){
-        this.manager.unselect();
+     * @name unselect
+     * @description unselect the icon
+     */
+    public void unselect () {
+        this.manager.unselect ();
         this.get_style_context ().remove_class ("df_selected");
     }
 
     /**
-    * @name is_selected
-    * @description check whether the item is selected or not
-    * @return bool true->is selected
-    */
-    public bool is_selected(){
-        return this.manager.is_selected();
+     * @name is_selected
+     * @description check whether the item is selected or not
+     * @return bool true->is selected
+     */
+    public bool is_selected () {
+        return this.manager.is_selected ();
     }
 
     /**
-    * @name on_release
-    * @description the release button event
-    * @param EventButton event the event produced
-    * @return bool @see on_release signal
-    */
-    private bool on_release(Gdk.EventButton event){
+     * @name on_release
+     * @description the release button event
+     * @param EventButton event the event produced
+     * @return bool @see on_release signal
+     */
+    private bool on_release (Gdk.EventButton event) {
         /*
-        //TODO IF WE DO THIS ON PRESS EVENT, THE MOTION IS ALTERED
-        //I'VE NOT FOUND A WAY TO ALTER THE Z ORDER WITHOUT REMOVING AND ADDING AGAIN FROM CONTAINER :(
-        //we will move to top this icon
-        Gtk.Allocation allocation;
-        this.get_allocation(out allocation);
-         //HELP! don't know why these constants?? maybe padding??
-        int x=allocation.x - PADDING_X;
-        int y=allocation.y - PADDING_Y;
-        ((FolderWindow)this.manager.get_application_window()).raise(this,x,y);
+           //TODO IF WE DO THIS ON PRESS EVENT, THE MOTION IS ALTERED
+           //I'VE NOT FOUND A WAY TO ALTER THE Z ORDER WITHOUT REMOVING AND ADDING AGAIN FROM CONTAINER :(
+           //we will move to top this icon
+           Gtk.Allocation allocation;
+           this.get_allocation(out allocation);
+           //HELP! don't know why these constants?? maybe padding??
+           int x=allocation.x - PADDING_X;
+           int y=allocation.y - PADDING_Y;
+           ((FolderWindow)this.manager.get_application_window()).raise(this,x,y);
 
-        return true;
-        */
+           return true;
+         */
 
-        //if the icon wasnt moved, maybe we must execute it
-        //depending if the files preferences single-click was activated
+        // if the icon wasnt moved, maybe we must execute it
+        // depending if the files preferences single-click was activated
 
-        //we notify that we are stopping to move
-        this.manager.get_folder().get_view().on_item_moving(false);
+        // we notify that we are stopping to move
+        this.manager.get_folder ().get_view ().on_item_moving (false);
 
-        if(!this.flagMoved){
-            bool single_click=false;
-            try{
-                GLib.File f_check_elementary=GLib.File.new_for_path ("/usr/share/glib-2.0/schemas/org.pantheon.files.gschema.xml");
-                if(f_check_elementary.query_exists()){
-                    //it seems we can't control an error reading settings!!
-                    GLib.Settings elementary_files_settings=new GLib.Settings("org.pantheon.files.preferences");
-                    single_click=elementary_files_settings.get_boolean("single-click");
-                    //debug("single_click: %s",(single_click?"true":"false"));
+        if (!this.flagMoved) {
+            bool single_click = false;
+            try {
+                GLib.File f_check_elementary = GLib.File.new_for_path ("/usr/share/glib-2.0/schemas/org.pantheon.files.gschema.xml");
+                if (f_check_elementary.query_exists ()) {
+                    // it seems we can't control an error reading settings!!
+                    GLib.Settings elementary_files_settings = new GLib.Settings ("org.pantheon.files.preferences");
+                    single_click = elementary_files_settings.get_boolean ("single-click");
+                    // debug("single_click: %s",(single_click?"true":"false"));
                 }
-            }catch(Error error){
-                //we don't have any files settngs, using default config
-                single_click=false;
+            } catch (Error error) {
+                // we don't have any files settngs, using default config
+                single_click = false;
             }
 
-            if(single_click && event.type==Gdk.EventType.BUTTON_RELEASE && event.button==Gdk.BUTTON_PRIMARY){
-                on_double_click();
+            if (single_click && event.type == Gdk.EventType.BUTTON_RELEASE && event.button == Gdk.BUTTON_PRIMARY) {
+                on_double_click ();
             }
         }
 
@@ -415,301 +415,299 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
     }
 
     /**
-    * @name on_press
-    * @description the mouse press event captured
-    * @param EventButton event the event produced
-    * @return bool @see on_press signal
-    */
-    private bool on_press(Gdk.EventButton event){
-        //debug("press:%i",(int)event.button);
+     * @name on_press
+     * @description the mouse press event captured
+     * @param EventButton event the event produced
+     * @return bool @see on_press signal
+     */
+    private bool on_press (Gdk.EventButton event) {
+        // debug("press:%i",(int)event.button);
 
 
-        if (event.type == Gdk.EventType.BUTTON_PRESS && event.button==Gdk.BUTTON_PRIMARY) {
-            //first we must select the item
-            this.select();
-            this.flagMoved=false;
+        if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_PRIMARY) {
+            // first we must select the item
+            this.select ();
+            this.flagMoved = false;
 
             Gtk.Widget p = this.parent;
             // offset == distance of parent widget from edge of screen ...
-            p.get_window().get_position(out this.offsetx, out this.offsety);
-            //debug("offset:%i,%i",this.offsetx,this.offsety);
+            p.get_window ().get_position (out this.offsetx, out this.offsety);
+            // debug("offset:%i,%i",this.offsetx,this.offsety);
             // plus distance from pointer to edge of widget
 
-            this.offsetx += (int)event.x+PADDING_X;
-            this.offsety += (int)event.y+PADDING_Y;
+            this.offsetx += (int) event.x + PADDING_X;
+            this.offsety += (int) event.y + PADDING_Y;
 
             // maxx, maxy both relative to the parent
             // note that we're rounding down now so that these max values don't get
             // rounded upward later and push the widget off the edge of its parent.
             Gtk.Allocation pAllocation;
-            p.get_allocation(out pAllocation);
+            p.get_allocation (out pAllocation);
             Gtk.Allocation thisAllocation;
-            this.get_allocation(out thisAllocation);
-            this.maxx = RoundDownToMultiple(pAllocation.width - thisAllocation.width, this.manager.get_folder().get_view().get_sensitivity());
-            this.maxy = RoundDownToMultiple(pAllocation.height - thisAllocation.height, this.manager.get_folder().get_view().get_sensitivity());
-        }else if(event.type == Gdk.EventType.@2BUTTON_PRESS){
-            this.select();
-            on_double_click();
-        }else if(event.type==Gdk.EventType.BUTTON_PRESS && event.button==Gdk.BUTTON_SECONDARY){
-            this.select();
-            this.show_popup(event);
+            this.get_allocation (out thisAllocation);
+            this.maxx = RoundDownToMultiple (pAllocation.width - thisAllocation.width, this.manager.get_folder ().get_view ().get_sensitivity ());
+            this.maxy = RoundDownToMultiple (pAllocation.height - thisAllocation.height, this.manager.get_folder ().get_view ().get_sensitivity ());
+        } else if (event.type == Gdk.EventType.@2BUTTON_PRESS)   {
+            this.select ();
+            on_double_click ();
+        } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY)       {
+            this.select ();
+            this.show_popup (event);
         }
 
         return true;
     }
 
     /**
-    * @name on_double_click
-    * @description double click event captured
-    */
-    private void on_double_click(){
-        //debug("doble click! %s",this.fileName);
-        this.execute();
+     * @name on_double_click
+     * @description double click event captured
+     */
+    private void on_double_click () {
+        // debug("doble click! %s",this.fileName);
+        this.execute ();
     }
 
     /**
-    * @name execute
-    * @description execute the action associated with the item
-    */
-    public void execute(){
-        this.manager.execute();
+     * @name execute
+     * @description execute the action associated with the item
+     */
+    public void execute () {
+        this.manager.execute ();
     }
 
     /**
-    * @name show_popup
-    * @description show the context popup for this item
-    * @param EventButton event the event button that originates this context menu
-    */
-    private void show_popup(Gdk.EventButton event){
-        //debug("evento:%f,%f",event.x,event.y);
-        //if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
+     * @name show_popup
+     * @description show the context popup for this item
+     * @param EventButton event the event button that originates this context menu
+     */
+    private void show_popup (Gdk.EventButton event) {
+        // debug("evento:%f,%f",event.x,event.y);
+        // if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
 
-            //building the menu
-            this.menu = new Gtk.Menu ();
+        // building the menu
+        this.menu = new Gtk.Menu ();
 
-            var label=DesktopFolder.Lang.ITEM_MENU_OPEN;
-            if(this.manager.is_executable()){
-                label=DesktopFolder.Lang.ITEM_MENU_EXECUTE;
-            }
-            Gtk.MenuItem item = new Gtk.MenuItem.with_label (label);
-            item.activate.connect ((item)=>{
-                this.manager.execute();
-            });
-            item.show();
-            menu.append (item);
-
-            item = new MenuItemSeparator();
-            item.show();
-            menu.append (item);
-
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_CUT);
-            item.activate.connect ((item)=>{this.manager.cut();});
-            item.show();
-            menu.append (item);
-
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_COPY);
-            item.activate.connect ((item)=>{this.manager.copy();});
-            item.show();
-            menu.append (item);
-
-            item = new MenuItemSeparator();
-            item.show();
-            menu.append (item);
-
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_RENAME);
-            item.activate.connect ((item)=>{this.rename_dialog();});
-            item.show();
-            menu.append (item);
-
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_DELETE);
-            item.activate.connect ((item)=>{this.delete_dialog();});
-            item.show();
-            menu.append (item);
-
-            if(this.manager.is_executable()){
-                item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_CHANGEICON);
-                item.activate.connect ((item)=>{this.change_icon();});
-                item.show();
-                menu.append (item);
-            }
-
-            menu.show_all();
-        //}
-
-        //showing the menu
-        menu.popup(
-             null //parent menu shell
-            ,null //parent menu item
-            ,null //func
-            ,event.button // button
-            ,event.get_time() //Gtk.get_current_event_time() //time
-            );
-    }
-
-    /**
-    * @name cut
-    * @description cut the file to the clipboard
-    */
-    public void cut(){
-        this.manager.cut();
-    }
-
-    /**
-    * @name copy
-    * @description copy the file to the clipboard
-    */
-    public void copy(){
-        this.manager.copy();
-    }
-
-    /**
-    * @name delete_dialog
-    * @description the user wants to delete the item. It should be confirmed before the deletion occurs
-    */
-    public void delete_dialog(){
-        string message=_(DesktopFolder.Lang.ITEM_DELETE_FOLDER_MESSAGE);
-        Gtk.Window window=(Gtk.Window) this.get_toplevel();
-        bool isdir=this.manager.is_folder();
-        if(!isdir){
-            message=DesktopFolder.Lang.ITEM_DELETE_FILE_MESSAGE;
+        var label = DesktopFolder.Lang.ITEM_MENU_OPEN;
+        if (this.manager.is_executable ()) {
+            label = DesktopFolder.Lang.ITEM_MENU_EXECUTE;
         }
-        if(this.manager.is_link()){
-            message=DesktopFolder.Lang.ITEM_DELETE_LINK_MESSAGE;
+        Gtk.MenuItem item = new Gtk.MenuItem.with_label (label);
+        item.activate.connect ((item) => {
+            this.manager.execute ();
+        });
+        item.show ();
+        menu.append (item);
+
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
+
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_CUT);
+        item.activate.connect ((item) => { this.manager.cut (); });
+        item.show ();
+        menu.append (item);
+
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_COPY);
+        item.activate.connect ((item) => { this.manager.copy (); });
+        item.show ();
+        menu.append (item);
+
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
+
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_RENAME);
+        item.activate.connect ((item) => { this.rename_dialog (); });
+        item.show ();
+        menu.append (item);
+
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_DELETE);
+        item.activate.connect ((item) => { this.delete_dialog (); });
+        item.show ();
+        menu.append (item);
+
+        if (this.manager.is_executable ()) {
+            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_CHANGEICON);
+            item.activate.connect ((item) => { this.change_icon (); });
+            item.show ();
+            menu.append (item);
+        }
+
+        menu.show_all ();
+        // }
+
+        // showing the menu
+        menu.popup (
+            null  // parent menu shell
+            , null // parent menu item
+            , null // func
+            , event.button // button
+            , event.get_time () // Gtk.get_current_event_time() //time
+        );
+    }
+
+    /**
+     * @name cut
+     * @description cut the file to the clipboard
+     */
+    public void cut () {
+        this.manager.cut ();
+    }
+
+    /**
+     * @name copy
+     * @description copy the file to the clipboard
+     */
+    public void copy () {
+        this.manager.copy ();
+    }
+
+    /**
+     * @name delete_dialog
+     * @description the user wants to delete the item. It should be confirmed before the deletion occurs
+     */
+    public void delete_dialog () {
+        string     message = _ (DesktopFolder.Lang.ITEM_DELETE_FOLDER_MESSAGE);
+        Gtk.Window window  = (Gtk.Window) this.get_toplevel ();
+        bool       isdir   = this.manager.is_folder ();
+        if (!isdir) {
+            message = DesktopFolder.Lang.ITEM_DELETE_FILE_MESSAGE;
+        }
+        if (this.manager.is_link ()) {
+            message = DesktopFolder.Lang.ITEM_DELETE_LINK_MESSAGE;
         }
 
         Gtk.MessageDialog msg = new Gtk.MessageDialog (window, Gtk.DialogFlags.MODAL,
-                                Gtk.MessageType.WARNING, Gtk.ButtonsType.OK_CANCEL, message);
-        msg.use_markup=true;
+                                                       Gtk.MessageType.WARNING, Gtk.ButtonsType.OK_CANCEL, message);
+        msg.use_markup = true;
         msg.response.connect ((response_id) => {
             switch (response_id) {
-				case Gtk.ResponseType.OK:
-                    msg.destroy();
-                    if(isdir){
-                        this.manager.delete();
-                        break;
-                    }else{
-                        this.manager.delete();
-                    }
-					break;
-                default:
-                    msg.destroy();
+            case Gtk.ResponseType.OK:
+                msg.destroy ();
+                if (isdir) {
+                    this.manager.delete ();
                     break;
-                    //uff
+                } else {
+                    this.manager.delete ();
+                }
+                break;
+            default:
+                msg.destroy ();
+                break;
+                // uff
             }
         });
         msg.show ();
     }
 
     /**
-    * @name rename_dialog
-    * @description the user wants to rename the icon. Some info is needed before the rename action is performed.
-    */
-    public void rename_dialog(){
-        RenameDialog dialog = new RenameDialog (this.manager.get_application_window(),
+     * @name rename_dialog
+     * @description the user wants to rename the icon. Some info is needed before the rename action is performed.
+     */
+    public void rename_dialog () {
+        RenameDialog dialog = new RenameDialog (this.manager.get_application_window (),
                                                 DesktopFolder.Lang.ITEM_RENAME_TITLE,
                                                 DesktopFolder.Lang.ITEM_RENAME_MESSAGE,
-                                                this.label.get_label());
-        dialog.on_rename.connect((new_name)=>{
-            //renaming
-            if(new_name!=this.label.get_label()){
-                this.rename(new_name);
+                                                this.label.get_label ());
+        dialog.on_rename.connect ((new_name) => {
+            // renaming
+            if (new_name != this.label.get_label ()) {
+                this.rename (new_name);
             }
         });
         dialog.show_all ();
     }
 
     /**
-    * @name change_icon
-    * @description change the icon of an executable item
-    */
-    private void change_icon(){
+     * @name change_icon
+     * @description change the icon of an executable item
+     */
+    private void change_icon () {
         Gtk.FileChooserDialog chooser = new Gtk.FileChooserDialog (
-				DesktopFolder.Lang.ITEM_CHANGEICON_MESSAGE, this.manager.get_application_window(),
-                Gtk.FileChooserAction.OPEN,
-				DesktopFolder.Lang.DIALOG_CANCEL,
-				Gtk.ResponseType.CANCEL,
-				DesktopFolder.Lang.DIALOG_SELECT,
-				Gtk.ResponseType.ACCEPT);
+            DesktopFolder.Lang.ITEM_CHANGEICON_MESSAGE, this.manager.get_application_window (),
+            Gtk.FileChooserAction.OPEN,
+            DesktopFolder.Lang.DIALOG_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            DesktopFolder.Lang.DIALOG_SELECT,
+            Gtk.ResponseType.ACCEPT);
 
-          Gtk.FileFilter filter = new Gtk.FileFilter();
-          filter.set_name("Images");
-          filter.add_mime_type("image");
-          filter.add_mime_type("image/png");
-          filter.add_mime_type("image/jpeg");
-          filter.add_mime_type("image/gif");
-          filter.add_pattern("*.png");
-          filter.add_pattern("*.jpg");
-          filter.add_pattern("*.gif");
-          filter.add_pattern("*.tif");
-          filter.add_pattern("*.xpm");
-          chooser.add_filter(filter);
+        Gtk.FileFilter filter = new Gtk.FileFilter ();
+        filter.set_name ("Images");
+        filter.add_mime_type ("image");
+        filter.add_mime_type ("image/png");
+        filter.add_mime_type ("image/jpeg");
+        filter.add_mime_type ("image/gif");
+        filter.add_pattern ("*.png");
+        filter.add_pattern ("*.jpg");
+        filter.add_pattern ("*.gif");
+        filter.add_pattern ("*.tif");
+        filter.add_pattern ("*.xpm");
+        chooser.add_filter (filter);
 
         // Process response:
-		if (chooser.run () == Gtk.ResponseType.ACCEPT) {
-            var filename=chooser.get_filename();
-            this.manager.change_icon(filename);
-		}
-        chooser.close();
+        if (chooser.run () == Gtk.ResponseType.ACCEPT) {
+            var filename = chooser.get_filename ();
+            this.manager.change_icon (filename);
+        }
+        chooser.close ();
     }
 
-
     /**
-    * @name on_motion
-    * @description the on_motion event captured to allow the movement of the icon
-    * @param EventMotion event @see the on_motion signal
-    * @return bool @see the on_motion signal
-    */
-    private bool on_motion(Gdk.EventMotion event){
-        //debug("on_motion");
-        this.flagModified=true;
+     * @name on_motion
+     * @description the on_motion event captured to allow the movement of the icon
+     * @param EventMotion event @see the on_motion signal
+     * @return bool @see the on_motion signal
+     */
+    private bool on_motion (Gdk.EventMotion event) {
+        // debug("on_motion");
+        this.flagModified = true;
 
-        if(!this.flagMoved){
-            //we notify that we are starting to move
-            this.manager.get_folder().get_view().on_item_moving(true);
-            this.flagMoved=true;
+        if (!this.flagMoved) {
+            // we notify that we are starting to move
+            this.manager.get_folder ().get_view ().on_item_moving (true);
+            this.flagMoved = true;
         }
 
         // x_root,x_root relative to screen
-    	// x,y relative to parent (fixed widget)
-    	// px,py stores previous values of x,y
+        // x,y relative to parent (fixed widget)
+        // px,py stores previous values of x,y
 
-    	// get starting values for x,y
-    	int x = (int)event.x_root - this.offsetx;
-    	int y = (int)event.y_root - this.offsety;
+        // get starting values for x,y
+        int x = (int) event.x_root - this.offsetx;
+        int y = (int) event.y_root - this.offsety;
 
         // make sure the potential coordinates x,y:
-    	//   1) will not push any part of the widget outside of its parent container
-    	//   2) is a multiple of Sensitivity
-    	x = RoundToNearestMultiple(int.max(int.min(x, this.maxx), 0), this.manager.get_folder().get_view().get_sensitivity());
-    	y = RoundToNearestMultiple(int.max(int.min(y, this.maxy), 0), this.manager.get_folder().get_view().get_sensitivity());
-    	if (x != this.px || y != this.py) {
-    		this.px = x;
-    		this.py = y;
+        // 1) will not push any part of the widget outside of its parent container
+        // 2) is a multiple of Sensitivity
+        x = RoundToNearestMultiple (int.max (int.min (x, this.maxx), 0), this.manager.get_folder ().get_view ().get_sensitivity ());
+        y = RoundToNearestMultiple (int.max (int.min (y, this.maxy), 0), this.manager.get_folder ().get_view ().get_sensitivity ());
+        if (x != this.px || y != this.py) {
+            this.px = x;
+            this.py = y;
 
-            Gtk.Window window=(Gtk.Window) this.get_toplevel();
-            ((FolderWindow)window).move_item(this,x,y);
-    	}
+            Gtk.Window window = (Gtk.Window) this.get_toplevel ();
+            ((FolderWindow) window).move_item (this, x, y);
+        }
 
-    	return true;
+        return true;
     }
 
     /**
-    * @name RoundDownToMultiple
-    * @description util function for the movement of icons
-    */
-    inline static int RoundDownToMultiple( int i,  int m)
-    {
-    	return i/m*m;
+     * @name RoundDownToMultiple
+     * @description util function for the movement of icons
+     */
+    inline static int RoundDownToMultiple (int i, int m) {
+        return i / m * m;
     }
 
     /**
-    * @name RoundToNearestMultiple
-    * @description util function for the movement of icons
-    */
-    public static int RoundToNearestMultiple( int i, int m)
-    {
-    	if (i % m > (double)m / 2.0d)
-    		return (i/m+1)*m;
-    	return i/m*m;
+     * @name RoundToNearestMultiple
+     * @description util function for the movement of icons
+     */
+    public static int RoundToNearestMultiple (int i, int m) {
+        if (i % m > (double) m / 2.0d)
+            return (i / m + 1) * m;
+        return i / m * m;
     }
+
 }

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -447,10 +447,10 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
             this.get_allocation (out thisAllocation);
             this.maxx = RoundDownToMultiple (pAllocation.width - thisAllocation.width, this.manager.get_folder ().get_view ().get_sensitivity ());
             this.maxy = RoundDownToMultiple (pAllocation.height - thisAllocation.height, this.manager.get_folder ().get_view ().get_sensitivity ());
-        } else if (event.type == Gdk.EventType.@2BUTTON_PRESS)   {
+        } else if (event.type == Gdk.EventType.@2BUTTON_PRESS) {
             this.select ();
             on_double_click ();
-        } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY)       {
+        } else if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_SECONDARY) {
             this.select ();
             this.show_popup (event);
         }
@@ -538,7 +538,7 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
 
         // showing the menu
         menu.popup (
-            null  // parent menu shell
+            null // parent menu shell
             , null // parent menu item
             , null // func
             , event.button // button
@@ -561,7 +561,7 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
     public void copy () {
         this.manager.copy ();
     }
-    
+
     /**
      * @name copy
      * @description copy the file to the clipboard

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -1,43 +1,43 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Folder Window that is shown above the desktop to manage files and folders
-*/
-public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow{
+ * @class
+ * Folder Window that is shown above the desktop to manage files and folders
+ */
+public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
     /** parent manager of this window */
-    private NoteManager manager=null;
+    private NoteManager manager           = null;
     /** Context menu of the Folder Window */
-    private Gtk.Menu menu=null;
+    private Gtk.Menu menu                 = null;
     /** the text view */
-    private Gtk.SourceView text=null;
+    private Gtk.SourceView text           = null;
     /** the texture pattern for the note */
-    private Cairo.Pattern texture_pattern=null;
+    private Cairo.Pattern texture_pattern = null;
     /** the clip image prepared to be rendered */
-    private Cairo.Surface clip_surface=null;
+    private Cairo.Surface clip_surface    = null;
 
     /** head tags colors */
-    private const string HEAD_TAGS_COLORS[3] = { null, "#ffffff", "#000000"};
-    private const string HEAD_TAGS_COLORS_CLASS[3] = { "df_headless", "df_light", "df_dark"};
+    private const string HEAD_TAGS_COLORS[3]        = { null, "#ffffff", "#000000" };
+    private const string HEAD_TAGS_COLORS_CLASS[3]  = { "df_headless", "df_light", "df_dark" };
     /** body tags colors */
-    private const string BODY_TAGS_COLORS[10] = { null, "#ffe16b", "#ffa154", "#795548", "#9bdb4d", "#64baff", "#ad65d6", "#ed5353", "#d4d4d4", "#000000" };
+    private const string BODY_TAGS_COLORS[10]       = { null, "#ffe16b", "#ffa154", "#795548", "#9bdb4d", "#64baff", "#ad65d6", "#ed5353", "#d4d4d4", "#000000" };
     private const string BODY_TAGS_COLORS_CLASS[10] = { "df_transparent", "df_yellow", "df_orange", "df_brown", "df_green", "df_blue", "df_purple", "df_red", "df_gray", "df_black" };
 
     static construct {
@@ -48,385 +48,385 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow{
         set_keep_below (true);
         stick ();
         this.hide_titlebar_when_maximized = false;
-        set_type_hint(Gdk.WindowTypeHint.MENU);
-        set_skip_taskbar_hint(true);
-        this.set_property("skip-taskbar-hint", true);
+        set_type_hint (Gdk.WindowTypeHint.MENU);
+        set_skip_taskbar_hint (true);
+        this.set_property ("skip-taskbar-hint", true);
     }
 
     /**
-    * @constructor
-    * @param FolderManager manager the manager of this window
-    */
-    public NoteWindow (NoteManager manager){
-        Object (application: manager.get_application(),
-                icon_name: "com.github.spheras.desktopfolder",
-                resizable: true,
-                skip_taskbar_hint : true,
-                type_hint:Gdk.WindowTypeHint.DESKTOP,
-                decorated:true,
-                title: (manager.get_note_name()),
-                deletable:false,
-                width_request: 140,
-                height_request: 160
-                );
+     * @constructor
+     * @param FolderManager manager the manager of this window
+     */
+    public NoteWindow (NoteManager manager) {
+        Object (
+            application:        manager.get_application (),
+            icon_name:          "com.github.spheras.desktopfolder",
+            resizable:          true,
+            skip_taskbar_hint:  true,
+            type_hint:          Gdk.WindowTypeHint.DESKTOP,
+            decorated:          true,
+            title:              (manager.get_note_name ()),
+            deletable:          false,
+            width_request:      140,
+            height_request:     160
+        );
 
-        var headerbar = new Gtk.HeaderBar();
-        headerbar.set_title(manager.get_note_name());
-        //headerbar.set_subtitle("HeaderBar Subtitle");
-        //headerbar.set_show_close_button(true);
-        this.set_titlebar(headerbar);
+        var headerbar = new Gtk.HeaderBar ();
+        headerbar.set_title (manager.get_note_name ());
+        // headerbar.set_subtitle("HeaderBar Subtitle");
+        // headerbar.set_show_close_button(true);
+        this.set_titlebar (headerbar);
 
-        this.set_skip_taskbar_hint(true);
-        this.set_property("skip-taskbar-hint", true);
-        //setting the folder name
-        this.manager=manager;
+        this.set_skip_taskbar_hint (true);
+        this.set_property ("skip-taskbar-hint", true);
+        // setting the folder name
+        this.manager = manager;
 
-        //let's load the settings of the folder (if exist or a new one)
-        NoteSettings settings=this.manager.get_settings();
-        if(settings.w>0){
-            //applying existing position and size configuration
-            this.resize(settings.w,settings.h);
+        // let's load the settings of the folder (if exist or a new one)
+        NoteSettings settings = this.manager.get_settings ();
+        if (settings.w > 0) {
+            // applying existing position and size configuration
+            this.resize (settings.w, settings.h);
         }
-        if(settings.x>0 || settings.y>0){
-            this.move(settings.x,settings.y);
+        if (settings.x > 0 || settings.y > 0) {
+            this.move (settings.x, settings.y);
         }
-        //we set a class to this window to manage the css
+        // we set a class to this window to manage the css
         this.get_style_context ().add_class ("df_folder");
         this.get_style_context ().add_class ("df_note");
         this.get_style_context ().add_class ("df_shadow");
-        //applying existing colors configuration
+        // applying existing colors configuration
         this.get_style_context ().add_class (settings.bgcolor);
         this.get_style_context ().add_class (settings.fgcolor);
 
         // Box:
-		Gtk.Box box = new Gtk.Box (Gtk.Orientation.VERTICAL, 1);
+        Gtk.Box box = new Gtk.Box (Gtk.Orientation.VERTICAL, 1);
         box.get_style_context ().add_class ("df_note_container");
-        box.set_border_width(20);
-		this.add (box);
+        box.set_border_width (20);
+        this.add (box);
 
         // A ScrolledWindow:
-		Gtk.ScrolledWindow scrolled = new Gtk.ScrolledWindow (null, null);
+        Gtk.ScrolledWindow scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.get_style_context ().add_class ("df_note_scroll");
-		box.pack_start (scrolled, true, true, 0);
+        box.pack_start (scrolled, true, true, 0);
 
         // The TextView:
-	    this.text = new Gtk.SourceView(); //Gtk.TextView ();
-		this.text.set_wrap_mode (Gtk.WrapMode.WORD);
+        this.text = new Gtk.SourceView (); // Gtk.TextView ();
+        this.text.set_wrap_mode (Gtk.WrapMode.WORD);
         this.text.get_style_context ().add_class ("df_note_text");
-		this.text.buffer.text = this.manager.get_settings().text;
-		scrolled.add (this.text);
+        this.text.buffer.text = this.manager.get_settings ().text;
+        scrolled.add (this.text);
 
-        this.show_all();
+        this.show_all ();
 
-        //connecting to events
+        // connecting to events
         this.configure_event.connect (this.on_configure);
-        this.button_press_event.connect(this.on_press);
-        this.button_release_event.connect(this.on_release);
-        this.draw.connect(this.draw_background);
+        this.button_press_event.connect (this.on_press);
+        this.button_release_event.connect (this.on_release);
+        this.draw.connect (this.draw_background);
 
-        text.focus_out_event.connect(this.on_focus_out);
-        //this.key_release_event.connect(this.on_key);
+        text.focus_out_event.connect (this.on_focus_out);
+        // this.key_release_event.connect(this.on_key);
 
-        //help: doesn't have the gtk window any active signal? or css :active state?
-        Wnck.Screen screen = Wnck.Screen.get_default();
-        screen.active_window_changed.connect(on_active_change);
+        // help: doesn't have the gtk window any active signal? or css :active state?
+        Wnck.Screen screen = Wnck.Screen.get_default ();
+        screen.active_window_changed.connect (on_active_change);
     }
 
     /**
-    * @name on_active_change
-    * @description the screen actived window has change signal
-    * @param {Wnck.Window} the previous actived window
-    */
-    private void on_active_change(Wnck.Window? previous){
-        string sclass="df_active";
-        Gtk.StyleContext style=this.get_style_context();
-        if(this.is_active){
-            if(!style.has_class(sclass)){
-                //debug("active");
+     * @name on_active_change
+     * @description the screen actived window has change signal
+     * @param {Wnck.Window} the previous actived window
+     */
+    private void on_active_change (Wnck.Window ? previous) {
+        string           sclass = "df_active";
+        Gtk.StyleContext style  = this.get_style_context ();
+        if (this.is_active) {
+            if (!style.has_class (sclass)) {
+                // debug("active");
                 style.add_class ("df_active");
-                //we need to force a queue_draw
-                this.queue_draw();
-                this.text.queue_draw();
+                // we need to force a queue_draw
+                this.queue_draw ();
+                this.text.queue_draw ();
             }
-        }else{
-            if(style.has_class(sclass)){
-                //debug("inactive");
+        } else {
+            if (style.has_class (sclass)) {
+                // debug("inactive");
                 style.remove_class ("df_active");
-                this.type_hint=Gdk.WindowTypeHint.DESKTOP;
-                //we need to force a queue_draw
-                this.queue_draw();
-                this.text.queue_draw();
+                this.type_hint = Gdk.WindowTypeHint.DESKTOP;
+                // we need to force a queue_draw
+                this.queue_draw ();
+                this.text.queue_draw ();
             }
         }
     }
 
     /**
-    * @name on_focus_out
-    * @description focus out event
-    * @param {Gdk.EventFocus} event the event launched
-    * @return bool @see focus_out_event signal
-    */
-    private bool on_focus_out (Gdk.EventFocus event){
-        //we are now a dock Window, to avoid minimization when show desktop
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_focus_out
+     * @description focus out event
+     * @param {Gdk.EventFocus} event the event launched
+     * @return bool @see focus_out_event signal
+     */
+    private bool on_focus_out (Gdk.EventFocus event) {
+        // we are now a dock Window, to avoid minimization when show desktop
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
 
-        var buffer=this.text.get_buffer();
-        var text=buffer.text;
-        var saved_text=this.manager.get_settings().text;
-        if(text!=saved_text){
-            this.manager.on_text_change(text);
+        var buffer     = this.text.get_buffer ();
+        var text       = buffer.text;
+        var saved_text = this.manager.get_settings ().text;
+        if (text != saved_text) {
+            this.manager.on_text_change (text);
         }
         return false;
     }
 
     /**
-    * @name on_configure
-    * @description the configure event is produced when the window change its dimensions or location settings
-    */
-    private bool on_configure(Gdk.EventConfigure event){
-        if(event.type==Gdk.EventType.CONFIGURE){
-            //we are now a dock Window, to avoid minimization when show desktop
-            //TODO exists a way to make resizable and moveable a dock window?
-            //this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_configure
+     * @description the configure event is produced when the window change its dimensions or location settings
+     */
+    private bool on_configure (Gdk.EventConfigure event) {
+        if (event.type == Gdk.EventType.CONFIGURE) {
+            // we are now a dock Window, to avoid minimization when show desktop
+            // TODO exists a way to make resizable and moveable a dock window?
+            // this.type_hint=Gdk.WindowTypeHint.DESKTOP;
 
-            //debug("configure event:%i,%i,%i,%i",event.x,event.y,event.width,event.height);
-            this.manager.set_new_shape(event.x, event.y, event.width, event.height);
+            // debug("configure event:%i,%i,%i,%i",event.x,event.y,event.width,event.height);
+            this.manager.set_new_shape (event.x, event.y, event.width, event.height);
         }
         return false;
     }
 
     /**
-    * @name on_release
-    * @description release event captured.
-    * @return bool @see widget on_release signal
-    */
-    private bool on_release(Gdk.EventButton event){
-        //we are now a dock Window, to avoid minimization when show desktop
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_release
+     * @description release event captured.
+     * @return bool @see widget on_release signal
+     */
+    private bool on_release (Gdk.EventButton event) {
+        // we are now a dock Window, to avoid minimization when show desktop
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
         return false;
     }
 
     /**
-    * @name on_press
-    * @description press event captured. The Window should show the popup on right button
-    * @return bool @see widget on_press signal
-    */
-    private bool on_press(Gdk.EventButton event){
-        //we are now a normal Window, to allow resizing and movement
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.NORMAL;
+     * @name on_press
+     * @description press event captured. The Window should show the popup on right button
+     * @return bool @see widget on_press signal
+     */
+    private bool on_press (Gdk.EventButton event) {
+        // we are now a normal Window, to allow resizing and movement
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.NORMAL;
 
-        //debug("press:%i,%i",(int)event.button,(int)event.y);
+        // debug("press:%i,%i",(int)event.button,(int)event.y);
         if (event.type == Gdk.EventType.BUTTON_PRESS &&
-            (event.button==Gdk.BUTTON_SECONDARY)) {
-            this.show_popup(event);
+            (event.button == Gdk.BUTTON_SECONDARY)) {
+            this.show_popup (event);
             return true;
         }
         return false;
     }
 
     /**
-    * @name show_popup
-    * @description build and show the popup menu
-    * @param event EventButton the origin event, needed to position the menu
-    */
-    private void show_popup(Gdk.EventButton event){
-        //debug("evento:%f,%f",event.x,event.y);
-        //if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
+     * @name show_popup
+     * @description build and show the popup menu
+     * @param event EventButton the origin event, needed to position the menu
+     */
+    private void show_popup (Gdk.EventButton event) {
+        // debug("evento:%f,%f",event.x,event.y);
+        // if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
 
-            //Forcing Dock mode to avoid minimization in certain extremely cases without on_press signal!
-            //TODO exists a way to make resizable and moveable a dock window?
-            this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+        // Forcing Dock mode to avoid minimization in certain extremely cases without on_press signal!
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
 
-            this.menu = new Gtk.Menu ();
+        this.menu      = new Gtk.Menu ();
 
-            // new submenu
-            Gtk.MenuItem item_new = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_SUBMENU);
-            item_new.show();
-            menu.append (item_new);
+        // new submenu
+        Gtk.MenuItem item_new = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_SUBMENU);
+        item_new.show ();
+        menu.append (item_new);
 
-            Gtk.Menu newmenu = new Gtk.Menu ();
-            item_new.set_submenu (newmenu);
+        Gtk.Menu newmenu = new Gtk.Menu ();
+        item_new.set_submenu (newmenu);
 
-            //menu to create a new folder
-            Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER);
-            item.activate.connect ((item)=>{
-                    this.new_desktop_folder();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new folder
+        Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER);
+        item.activate.connect ((item) => {
+            this.new_desktop_folder ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new note
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_NOTE);
-            item.activate.connect ((item)=>{
-                    this.new_note();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new note
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_NOTE);
+        item.activate.connect ((item) => {
+            this.new_note ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new photo
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
-            item.activate.connect ((item)=>{
-                    this.new_photo();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new photo
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
+        item.activate.connect ((item) => {
+            this.new_photo ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            item = new Gtk.CheckMenuItem.with_label(DesktopFolder.Lang.NOTE_MENU_PAPER_NOTE);
-            (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings().texture=="square_paper");
-            (item as Gtk.CheckMenuItem).toggled.connect ((item)=>{
-                this.on_texture("square_paper");
-            });
-            item.show();
-            menu.append (item);
+        item = new Gtk.CheckMenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_PAPER_NOTE);
+        (item as Gtk.CheckMenuItem).set_active (this.manager.get_settings ().texture == "square_paper");
+        (item as Gtk.CheckMenuItem).toggled.connect ((item) => {
+            this.on_texture ("square_paper");
+        });
+        item.show ();
+        menu.append (item);
 
 
-            item = new MenuItemSeparator();
-            item.show ();
-            menu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
 
-            //option to delete the current folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_DELETE_NOTE);
-            item.activate.connect ((item)=>{this.manager.delete();});
-            item.show();
-            menu.append (item);
+        // option to delete the current folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_DELETE_NOTE);
+        item.activate.connect ((item) => { this.manager.delete (); });
+        item.show ();
+        menu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show ();
-            menu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
 
-            //Option to rename the current folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_RENAME_NOTE);
-            item.activate.connect ((item)=>{this.rename_note();});
-            item.show();
-            menu.append (item);
+        // Option to rename the current folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_RENAME_NOTE);
+        item.activate.connect ((item) => { this.rename_note (); });
+        item.show ();
+        menu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show();
-            menu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
 
-            //section to change the window head and body colors
-            item = new MenuItemColor(HEAD_TAGS_COLORS);;
-            ((MenuItemColor)item).color_changed.connect(change_head_color);
-            item.show();
-            menu.append (item);
-            item = new MenuItemColor(BODY_TAGS_COLORS);;
-            ((MenuItemColor)item).color_changed.connect(change_body_color);
-            item.show();
-            menu.append (item);
+        // section to change the window head and body colors
+        item = new MenuItemColor (HEAD_TAGS_COLORS);;
+        ((MenuItemColor) item).color_changed.connect (change_head_color);
+        item.show ();
+        menu.append (item);
+        item = new MenuItemColor (BODY_TAGS_COLORS);;
+        ((MenuItemColor) item).color_changed.connect (change_body_color);
+        item.show ();
+        menu.append (item);
 
-        //}
+        // }
 
-        //finally we show the popup
-        menu.popup(
-             null //parent menu shell
-            ,null //parent menu item
-            ,null //func
-            ,event.button // button
-            ,event.get_time() //Gtk.get_current_event_time() //time
-            );
+        // finally we show the popup
+        menu.popup (
+            null // parent menu shell
+            , null // parent menu item
+            , null // func
+            , event.button // button
+            , event.get_time () // Gtk.get_current_event_time() //time
+        );
     }
 
-
     /**
-    * @name on_texture
-    * @description set the texture for the note window
-    * @param {string} texture the texture to apply
-    */
-    private void on_texture(string texture){
-        string current_texture=this.manager.get_settings().texture;
-        if(current_texture==texture){
-            this.manager.get_settings().texture="";
-        }else{
-            this.manager.get_settings().texture=texture;
+     * @name on_texture
+     * @description set the texture for the note window
+     * @param {string} texture the texture to apply
+     */
+    private void on_texture (string texture) {
+        string current_texture = this.manager.get_settings ().texture;
+        if (current_texture == texture) {
+            this.manager.get_settings ().texture = "";
+        } else {
+            this.manager.get_settings ().texture = texture;
         }
-        this.manager.get_settings().save();
-        this.queue_draw();
+        this.manager.get_settings ().save ();
+        this.queue_draw ();
     }
 
     /**
-    * @name new_photo
-    * @description show a dialog to create a new photo
-    */
-    private void new_photo(){
-        DesktopFolder.Util.create_new_photo(this);
+     * @name new_photo
+     * @description show a dialog to create a new photo
+     */
+    private void new_photo () {
+        DesktopFolder.Util.create_new_photo (this);
     }
 
     /**
-    * @name new_note
-    * @description show a dialog to create a new desktop folder
-    */
-    private void new_note(){
-        DesktopFolder.Util.create_new_note(this);
+     * @name new_note
+     * @description show a dialog to create a new desktop folder
+     */
+    private void new_note () {
+        DesktopFolder.Util.create_new_note (this);
     }
 
     /**
-    * @name new_desktop_folder
-    * @description show a dialog to create a new desktop folder
-    */
-    private void new_desktop_folder(){
-        DesktopFolder.Util.create_new_desktop_folder(this);
+     * @name new_desktop_folder
+     * @description show a dialog to create a new desktop folder
+     */
+    private void new_desktop_folder () {
+        DesktopFolder.Util.create_new_desktop_folder (this);
     }
 
     /**
-    * @name change_head_color
-    * @description change event captured from the popup for a new color to the head window
-    * @param ncolor int the new color for the head window
-    */
-    private void change_head_color(int ncolor){
-        string color=HEAD_TAGS_COLORS_CLASS[ncolor];
-        for(int i=0;i<HEAD_TAGS_COLORS_CLASS.length;i++){
-            string scolor=HEAD_TAGS_COLORS_CLASS[i];
-            this.get_style_context().remove_class (scolor);
+     * @name change_head_color
+     * @description change event captured from the popup for a new color to the head window
+     * @param ncolor int the new color for the head window
+     */
+    private void change_head_color (int ncolor) {
+        string color = HEAD_TAGS_COLORS_CLASS[ncolor];
+        for (int i = 0 ; i < HEAD_TAGS_COLORS_CLASS.length ; i++) {
+            string scolor = HEAD_TAGS_COLORS_CLASS[i];
+            this.get_style_context ().remove_class (scolor);
         }
         this.get_style_context ().add_class (color);
-        this.manager.save_head_color(color);
+        this.manager.save_head_color (color);
     }
 
     /**
-    * @name rename_note
-    * @description try to rename the current note
-    */
-    private void rename_note(){
+     * @name rename_note
+     * @description try to rename the current note
+     */
+    private void rename_note () {
         RenameDialog dialog = new RenameDialog (this,
                                                 DesktopFolder.Lang.NOTE_RENAME_TITLE,
                                                 DesktopFolder.Lang.NOTE_RENAME_MESSAGE,
-                                                this.manager.get_note_name());
-        dialog.on_rename.connect((new_name)=>{
-            if(this.manager.rename(new_name)){
-                this.set_title(new_name);
+                                                this.manager.get_note_name ());
+        dialog.on_rename.connect ((new_name) => {
+            if (this.manager.rename (new_name)) {
+                this.set_title (new_name);
             }
         });
         dialog.show_all ();
     }
 
     /**
-    * @name change_body_color
-    * @description change event captured from the popup for a new color to the body window
-    * @param ncolor int the new color for the body window
-    */
-    private void change_body_color(int ncolor){
-        string color=BODY_TAGS_COLORS_CLASS[ncolor];
-        for(int i=0;i<BODY_TAGS_COLORS_CLASS.length;i++){
-            string scolor=BODY_TAGS_COLORS_CLASS[i];
-            this.get_style_context().remove_class (scolor);
+     * @name change_body_color
+     * @description change event captured from the popup for a new color to the body window
+     * @param ncolor int the new color for the body window
+     */
+    private void change_body_color (int ncolor) {
+        string color = BODY_TAGS_COLORS_CLASS[ncolor];
+        for (int i = 0 ; i < BODY_TAGS_COLORS_CLASS.length ; i++) {
+            string scolor = BODY_TAGS_COLORS_CLASS[i];
+            this.get_style_context ().remove_class (scolor);
         }
 
-        this.get_style_context().add_class (color);
-        this.manager.save_body_color(color);
-        //debug("color:%d,%s",ncolor,color);
+        this.get_style_context ().add_class (color);
+        this.manager.save_body_color (color);
+        // debug("color:%d,%s",ncolor,color);
     }
 
     /**
-    * @name draw_backgorund
-    * @description draw the note window background intercepting the draw signal
-    * @param {Cairo.Context} cr the cairo context
-    * @bool @see draw signal
-    */
+     * @name draw_backgorund
+     * @description draw the note window background intercepting the draw signal
+     * @param {Cairo.Context} cr the cairo context
+     * @bool @see draw signal
+     */
     private bool draw_background (Cairo.Context cr) {
-        int width = this.get_allocated_width ();
+        int width  = this.get_allocated_width ();
         int height = this.get_allocated_height ();
 
         cr.set_operator (Cairo.Operator.CLEAR);
@@ -434,20 +434,20 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow{
         cr.set_operator (Cairo.Operator.OVER);
 
         /*
-        var background_style = this.get_style_context ();
-        background_style.render_background (cr, 0, 0, width, height);
-        background_style.render_frame (cr, 0, 0, width, height);
-        */
+           var background_style = this.get_style_context ();
+           background_style.render_background (cr, 0, 0, width, height);
+           background_style.render_frame (cr, 0, 0, width, height);
+         */
 
-        //shaping
-        shape(cr,width,height);
+        // shaping
+        shape (cr, width, height);
         cr.clip ();
 
-        if(this.manager.get_settings().texture=="square_paper"){
-            try{
-                if(this.texture_pattern==null){
-                    var pixbuf=new Gdk.Pixbuf.from_resource("/com/github/spheras/desktopfolder/hip-square.png");
-                    var surface=Gdk.cairo_surface_create_from_pixbuf(pixbuf,1,null);
+        if (this.manager.get_settings ().texture == "square_paper") {
+            try {
+                if (this.texture_pattern == null) {
+                    var pixbuf  = new Gdk.Pixbuf.from_resource ("/com/github/spheras/desktopfolder/hip-square.png");
+                    var surface = Gdk.cairo_surface_create_from_pixbuf (pixbuf, 1, null);
                     this.texture_pattern = new Cairo.Pattern.for_surface (surface);
                     this.texture_pattern.set_extend (Cairo.Extend.REPEAT);
                 }
@@ -455,103 +455,104 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow{
                 cr.set_source (this.texture_pattern);
                 cr.paint_with_alpha (0.9);
             } catch (Error e) {
-                //error! ??
+                // error! ??
                 stderr.printf ("Error: %s\n", e.message);
             }
         }
 
-        //drawing border
-        shape(cr,width,height);
+        // drawing border
+        shape (cr, width, height);
         cr.set_line_width (3.0);
         cr.set_source_rgba (0, 0, 0, 0.2);
-        cr.stroke();
+        cr.stroke ();
 
-        //drawing corner
-        draw_corner(cr,width,height);
+        // drawing corner
+        draw_corner (cr, width, height);
         cr.set_source_rgba (0, 0, 0, 0.4);
-        cr.stroke();
+        cr.stroke ();
 
         base.draw (cr);
 
-        cr.reset_clip();
+        cr.reset_clip ();
 
-        //drawing clip
-        try{
-            if(this.clip_surface==null){
-                int clipcolor=this.manager.get_settings().clipcolor;
-                var color="";
-                switch(clipcolor){
-                    case 1:
-                        color= "blue";
-                        break;
-                    case 2:
-                        color= "green";
-                        break;
-                    case 3:
-                        color= "orange";
-                        break;
-                    case 4:
-                        color= "pink";
-                        break;
-                    case 5:
-                        color= "red";
-                        break;
-                    default:
-                    case 6:
-                        color= "yellow";
-                        break;
+        // drawing clip
+        try {
+            if (this.clip_surface == null) {
+                int clipcolor = this.manager.get_settings ().clipcolor;
+                var color     = "";
+                switch (clipcolor) {
+                case 1:
+                    color = "blue";
+                    break;
+                case 2:
+                    color = "green";
+                    break;
+                case 3:
+                    color = "orange";
+                    break;
+                case 4:
+                    color = "pink";
+                    break;
+                case 5:
+                    color = "red";
+                    break;
+                default:
+                case 6:
+                    color = "yellow";
+                    break;
                 }
-                var pixbuf=new Gdk.Pixbuf.from_resource("/com/github/spheras/desktopfolder/clip-"+color+".png");
-                this.clip_surface=Gdk.cairo_surface_create_from_pixbuf(pixbuf, 1, null);
+                var pixbuf = new Gdk.Pixbuf.from_resource ("/com/github/spheras/desktopfolder/clip-" + color + ".png");
+                this.clip_surface = Gdk.cairo_surface_create_from_pixbuf (pixbuf, 1, null);
             }
             cr.set_source_surface (this.clip_surface, 5, 5);
-            cr.paint();
+            cr.paint ();
         } catch (Error e) {
-            //error! ??
+            // error! ??
             stderr.printf ("Error: %s\n", e.message);
         }
 
         return true;
     }
 
-    private void draw_corner(Cairo.Context cr, double width, double height){
-        int margin=15;
-        int rightRadius=25;
-        cr.move_to(width-margin-rightRadius,margin);
-        cr.line_to(width-margin-rightRadius,margin+rightRadius);
-        cr.line_to(width-margin,margin+rightRadius);
+    private void draw_corner (Cairo.Context cr, double width, double height) {
+        int margin      = 15;
+        int rightRadius = 25;
+        cr.move_to (width - margin - rightRadius, margin);
+        cr.line_to (width - margin - rightRadius, margin + rightRadius);
+        cr.line_to (width - margin, margin + rightRadius);
     }
 
     /**
-    * @name shape
-    * @description shape the window with the shape of a note
-    * @param {Cairo.Context} cr the context to draw
-    * @param double width the width of the window
-    * @param double height the height of the window
-    */
+     * @name shape
+     * @description shape the window with the shape of a note
+     * @param {Cairo.Context} cr the context to draw
+     * @param double width the width of the window
+     * @param double height the height of the window
+     */
     private void shape (Cairo.Context cr, double width, double height) {
-        int margin=15;
-        int radius=2;
-        int rightRadius=25;
+        int margin      = 15;
+        int radius      = 2;
+        int rightRadius = 25;
 
-        cr.move_to (margin,margin+radius);
+        cr.move_to (margin, margin + radius);
 
-        //  /
-        cr.line_to (margin+radius,margin);
+        ///
+        cr.line_to (margin + radius, margin);
         // -
-        cr.line_to (width-margin-rightRadius, margin);
-        // \
-        cr.line_to (width-margin, margin+rightRadius);
+        cr.line_to (width - margin - rightRadius, margin);
+        // \ (top right corner)
+        cr.line_to (width - margin, margin + rightRadius);
         // |
-        cr.line_to (width-margin,height-margin-radius);
-        // /
-        cr.line_to (width-margin-radius,height-margin);
+        cr.line_to (width - margin, height - margin - radius);
+        ///
+        cr.line_to (width - margin - radius, height - margin);
         // -
-        cr.line_to (margin+radius,height-margin);
-        // \
-        cr.line_to (margin,height-margin-radius);
+        cr.line_to (margin + radius, height - margin);
+        // \ (top right corner)
+        cr.line_to (margin, height - margin - radius);
         // |
-        cr.line_to(margin,margin+radius);
+        cr.line_to (margin, margin + radius);
         cr.close_path ();
     }
+
 }

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -290,7 +290,7 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
 
         // option to delete the current folder
         item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_DELETE_NOTE);
-        item.activate.connect ((item) => { this.manager.delete (); });
+        item.activate.connect ((item) => { this.manager.trash (); });
         item.show ();
         menu.append (item);
 

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -377,7 +377,7 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
      */
     private void change_head_color (int ncolor) {
         string color = HEAD_TAGS_COLORS_CLASS[ncolor];
-        for (int i = 0 ; i < HEAD_TAGS_COLORS_CLASS.length ; i++) {
+        for (int i = 0; i < HEAD_TAGS_COLORS_CLASS.length; i++) {
             string scolor = HEAD_TAGS_COLORS_CLASS[i];
             this.get_style_context ().remove_class (scolor);
         }
@@ -409,7 +409,7 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
      */
     private void change_body_color (int ncolor) {
         string color = BODY_TAGS_COLORS_CLASS[ncolor];
-        for (int i = 0 ; i < BODY_TAGS_COLORS_CLASS.length ; i++) {
+        for (int i = 0; i < BODY_TAGS_COLORS_CLASS.length; i++) {
             string scolor = BODY_TAGS_COLORS_CLASS[i];
             this.get_style_context ().remove_class (scolor);
         }

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -262,7 +262,7 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
 
         // finally we show the popup
         menu.popup (
-            null  // parent menu shell
+            null // parent menu shell
             , null // parent menu item
             , null // func
             , event.button // button

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -1,91 +1,88 @@
 /*
-* Copyright (c) 2017 José Amuedo (https://github.com/spheras)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * Copyright (c) 2017 José Amuedo (https://github.com/spheras)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
 /**
-* @class
-* Photo Window to show a photo
-*/
-public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow{
+ * @class
+ * Photo Window to show a photo
+ */
+public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
     /** parent manager of this window */
-    private PhotoManager manager=null;
+    private PhotoManager manager = null;
     /** Context menu of the Folder Window */
-    private Gtk.Menu menu=null;
+    private Gtk.Menu menu        = null;
 
-    //private const string FIXO_TAGS_COLORS[7] = { null, "#fce94f", "#8ae234", "#729fcf", "#fe44f8", "#FFFFFF", "#000000" };
+    // private const string FIXO_TAGS_COLORS[7] = { null, "#fce94f", "#8ae234", "#729fcf", "#fe44f8", "#FFFFFF", "#000000" };
     private const string FIXO_TAGS_COLORS[9] = { null, "#ffe16b", "#ffa154", "#9bdb4d", "#64baff", "#ad65d6", "#ed5353", "#ffffff", "#000000" };
 
-    //cached shadow photo and fixos
-    private Cairo.Surface shadowSurface=null;
-    private Cairo.Surface photoSurface=null;
-    private Gdk.Pixbuf fixoPixbuf=null;
-
-    static construct {
-
-    }
+    // cached shadow photo and fixos
+    private Cairo.Surface shadowSurface = null;
+    private Cairo.Surface photoSurface  = null;
+    private Gdk.Pixbuf fixoPixbuf       = null;
 
     construct {
         set_keep_below (true);
         stick ();
         this.hide_titlebar_when_maximized = false;
-        set_type_hint(Gdk.WindowTypeHint.MENU);
-        set_skip_taskbar_hint(true);
-        this.set_property("skip-taskbar-hint", true);
+        set_type_hint (Gdk.WindowTypeHint.MENU);
+        set_skip_taskbar_hint (true);
+        this.set_property ("skip-taskbar-hint", true);
     }
 
     /**
-    * @constructor
-    * @param FolderManager manager the manager of this window
-    */
-    public PhotoWindow (PhotoManager manager){
-        Object (application: manager.get_application(),
-                icon_name: "com.github.spheras.desktopfolder",
-                resizable: true,
-                skip_taskbar_hint : true,
-                decorated:true,
-                type_hint:Gdk.WindowTypeHint.DESKTOP,
-                title: (manager.get_photo_name()),
-                deletable:false,
-                width_request: 140,
-                height_request: 160
-                );
+     * @constructor
+     * @param FolderManager manager the manager of this window
+     */
+    public PhotoWindow (PhotoManager manager) {
+        Object (
+            application:        manager.get_application (),
+            icon_name:          "com.github.spheras.desktopfolder",
+            resizable:          true,
+            skip_taskbar_hint:  true,
+            decorated:          true,
+            type_hint:          Gdk.WindowTypeHint.DESKTOP,
+            title:              (manager.get_photo_name ()),
+            deletable:          false,
+            width_request:      140,
+            height_request:     160
+        );
 
-        var headerbar = new Gtk.HeaderBar();
-        headerbar.set_title(manager.get_photo_name());
-        //headerbar.set_subtitle("HeaderBar Subtitle");
-        //headerbar.set_show_close_button(true);
-        this.set_titlebar(headerbar);
+        var headerbar = new Gtk.HeaderBar ();
+        headerbar.set_title (manager.get_photo_name ());
+        // headerbar.set_subtitle("HeaderBar Subtitle");
+        // headerbar.set_show_close_button(true);
+        this.set_titlebar (headerbar);
 
-        this.set_skip_taskbar_hint(true);
-        this.set_property("skip-taskbar-hint", true);
-        //setting the folder name
-        this.manager=manager;
+        this.set_skip_taskbar_hint (true);
+        this.set_property ("skip-taskbar-hint", true);
+        // setting the folder name
+        this.manager = manager;
 
-        //let's load the settings of the folder (if exist or a new one)
-        PhotoSettings settings=this.manager.get_settings();
-        if(settings.w>0){
-            //applying existing position and size configuration
-            this.resize(settings.w,settings.h);
+        // let's load the settings of the folder (if exist or a new one)
+        PhotoSettings settings = this.manager.get_settings ();
+        if (settings.w > 0) {
+            // applying existing position and size configuration
+            this.resize (settings.w, settings.h);
         }
-        if(settings.x>0 || settings.y>0){
-            this.move(settings.x,settings.y);
+        if (settings.x > 0 || settings.y > 0) {
+            this.move (settings.x, settings.y);
         }
-        //we set a class to this window to manage the css
+        // we set a class to this window to manage the css
         this.get_style_context ().add_class ("df_folder");
         this.get_style_context ().add_class ("df_photo");
         this.get_style_context ().add_class ("df_transparent");
@@ -94,326 +91,325 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow{
         // Box:
         Gtk.Box box = new Gtk.Box (Gtk.Orientation.VERTICAL, 1);
         box.get_style_context ().add_class ("df_photo_container");
-        box.set_border_width(20);
-		this.add (box);
+        box.set_border_width (20);
+        this.add (box);
 
-        this.show_all();
+        this.show_all ();
 
-        //connecting to events
+        // connecting to events
         this.configure_event.connect (this.on_configure);
-        this.button_press_event.connect(this.on_press);
-        this.button_release_event.connect(this.on_release);
-        this.draw.connect(this.draw_background);
+        this.button_press_event.connect (this.on_press);
+        this.button_release_event.connect (this.on_release);
+        this.draw.connect (this.draw_background);
 
-        //help: doesn't have the gtk window any active signal? or css :active state?
-        Wnck.Screen screen = Wnck.Screen.get_default();
-        screen.active_window_changed.connect(on_active_change);
+        // help: doesn't have the gtk window any active signal? or css :active state?
+        Wnck.Screen screen = Wnck.Screen.get_default ();
+        screen.active_window_changed.connect (on_active_change);
     }
 
     /**
-    * @name on_active_change
-    * @description the screen actived window has change signal
-    * @param {Wnck.Window} the previous actived window
-    */
-    private void on_active_change(Wnck.Window? previous){
-        string sclass="df_active";
-        Gtk.StyleContext style=this.get_style_context();
-        if(this.is_active){
-            if(!style.has_class(sclass)){
+     * @name on_active_change
+     * @description the screen actived window has change signal
+     * @param {Wnck.Window} the previous actived window
+     */
+    private void on_active_change (Wnck.Window ? previous) {
+        string           sclass = "df_active";
+        Gtk.StyleContext style  = this.get_style_context ();
+        if (this.is_active) {
+            if (!style.has_class (sclass)) {
                 style.add_class ("df_active");
-                //we need to force a queue_draw
-                this.queue_draw();
+                // we need to force a queue_draw
+                this.queue_draw ();
             }
-        }else{
-            if(style.has_class(sclass)){
+        } else {
+            if (style.has_class (sclass)) {
                 style.remove_class ("df_active");
-                this.type_hint=Gdk.WindowTypeHint.DESKTOP;
-                //we need to force a queue_draw
-                this.queue_draw();
+                this.type_hint = Gdk.WindowTypeHint.DESKTOP;
+                // we need to force a queue_draw
+                this.queue_draw ();
             }
         }
     }
 
-
     /**
-    * @name on_configure
-    * @description the configure event is produced when the window change its dimensions or location settings
-    */
-    private bool on_configure(Gdk.EventConfigure event){
-        if(event.type==Gdk.EventType.CONFIGURE){
-            //we are now a dock Window, to avoid minimization when show desktop
-            //TODO exists a way to make resizable and moveable a dock window?
-            this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_configure
+     * @description the configure event is produced when the window change its dimensions or location settings
+     */
+    private bool on_configure (Gdk.EventConfigure event) {
+        if (event.type == Gdk.EventType.CONFIGURE) {
+            // we are now a dock Window, to avoid minimization when show desktop
+            // TODO exists a way to make resizable and moveable a dock window?
+            this.type_hint = Gdk.WindowTypeHint.DESKTOP;
 
-            //debug("configure event:%i,%i,%i,%i",event.x,event.y,event.width,event.height);
-            this.manager.set_new_shape(event.x, event.y, event.width, event.height);
+            // debug("configure event:%i,%i,%i,%i",event.x,event.y,event.width,event.height);
+            this.manager.set_new_shape (event.x, event.y, event.width, event.height);
 
-            //reseting cached images
-            this.shadowSurface=null;
-            this.photoSurface=null;
-            this.fixoPixbuf=null;
+            // reseting cached images
+            this.shadowSurface = null;
+            this.photoSurface  = null;
+            this.fixoPixbuf    = null;
         }
         return false;
     }
 
     /**
-    * @name on_release
-    * @description release event captured.
-    * @return bool @see widget on_release signal
-    */
-    private bool on_release(Gdk.EventButton event){
-        //we are now a dock Window, to avoid minimization when show desktop
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+     * @name on_release
+     * @description release event captured.
+     * @return bool @see widget on_release signal
+     */
+    private bool on_release (Gdk.EventButton event) {
+        // we are now a dock Window, to avoid minimization when show desktop
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
         return false;
     }
 
     /**
-    * @name on_press
-    * @description press event captured. The Window should show the popup on right button
-    * @return bool @see widget on_press signal
-    */
-    private bool on_press(Gdk.EventButton event){
-        //we are now a normal Window, to allow resizing and movement
-        //TODO exists a way to make resizable and moveable a dock window?
-        this.type_hint=Gdk.WindowTypeHint.NORMAL;
+     * @name on_press
+     * @description press event captured. The Window should show the popup on right button
+     * @return bool @see widget on_press signal
+     */
+    private bool on_press (Gdk.EventButton event) {
+        // we are now a normal Window, to allow resizing and movement
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.NORMAL;
 
-        //debug("press:%i,%i",(int)event.button,(int)event.y);
+        // debug("press:%i,%i",(int)event.button,(int)event.y);
         if (event.type == Gdk.EventType.BUTTON_PRESS &&
-            (event.button==Gdk.BUTTON_SECONDARY)) {
-            this.show_popup(event);
+            (event.button == Gdk.BUTTON_SECONDARY)) {
+            this.show_popup (event);
             return true;
-        }else if (event.type == Gdk.EventType.BUTTON_PRESS &&
-                 (event.button==Gdk.BUTTON_PRIMARY)) {
-            int width = this.get_allocated_width ();
+        } else if (event.type == Gdk.EventType.BUTTON_PRESS &&
+                   (event.button == Gdk.BUTTON_PRIMARY)) {
+            int width  = this.get_allocated_width ();
             int height = this.get_allocated_height ();
-            int margin=30;
-            //debug("x:%d,y:%d,width:%d,height:%d",(int)event.x,(int) event.y,width,height);
-            if(event.x>margin && event.y>margin && event.x<width-margin && event.y<height-margin){
-                this.begin_move_drag((int)event.button,(int) event.x_root,(int) event.y_root, event.time);
+            int margin = 30;
+            // debug("x:%d,y:%d,width:%d,height:%d",(int)event.x,(int) event.y,width,height);
+            if (event.x > margin && event.y > margin && event.x < width - margin && event.y < height - margin) {
+                this.begin_move_drag ((int) event.button, (int) event.x_root, (int) event.y_root, event.time);
             }
         }
         return false;
     }
 
     /**
-    * @name show_popup
-    * @description build and show the popup menu
-    * @param event EventButton the origin event, needed to position the menu
-    */
-    private void show_popup(Gdk.EventButton event){
-        //debug("evento:%f,%f",event.x,event.y);
-        //if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
+     * @name show_popup
+     * @description build and show the popup menu
+     * @param event EventButton the origin event, needed to position the menu
+     */
+    private void show_popup (Gdk.EventButton event) {
+        // debug("evento:%f,%f",event.x,event.y);
+        // if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
 
-            //Forcing Dock mode to avoid minimization in certain extremely cases without on_press signal!
-            //TODO exists a way to make resizable and moveable a dock window?
-            this.type_hint=Gdk.WindowTypeHint.DESKTOP;
+        // Forcing Dock mode to avoid minimization in certain extremely cases without on_press signal!
+        // TODO exists a way to make resizable and moveable a dock window?
+        this.type_hint = Gdk.WindowTypeHint.DESKTOP;
 
-            this.menu = new Gtk.Menu ();
+        this.menu      = new Gtk.Menu ();
 
-            // new submenu
-            Gtk.MenuItem item_new = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_SUBMENU);
-            item_new.show();
-            menu.append (item_new);
+        // new submenu
+        Gtk.MenuItem item_new = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_SUBMENU);
+        item_new.show ();
+        menu.append (item_new);
 
-            Gtk.Menu newmenu = new Gtk.Menu ();
-            item_new.set_submenu (newmenu);
+        Gtk.Menu newmenu = new Gtk.Menu ();
+        item_new.set_submenu (newmenu);
 
-            //menu to create a new folder
-            Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER);
-            item.activate.connect ((item)=>{
-                    this.new_desktop_folder();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new folder
+        Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_DESKTOP_FOLDER);
+        item.activate.connect ((item) => {
+            this.new_desktop_folder ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new note
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_NOTE);
-            item.activate.connect ((item)=>{
-                    this.new_note();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new note
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_NOTE);
+        item.activate.connect ((item) => {
+            this.new_note ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            //menu to create a new photo
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
-            item.activate.connect ((item)=>{
-                    this.new_photo();
-            });
-            item.show();
-            newmenu.append (item);
+        // menu to create a new photo
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
+        item.activate.connect ((item) => {
+            this.new_photo ();
+        });
+        item.show ();
+        newmenu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show ();
-            menu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
 
-            //option to delete the current folder
-            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.PHOTO_MENU_DELETE_PHOTO);
-            item.activate.connect ((item)=>{this.manager.delete();});
-            item.show();
-            menu.append (item);
+        // option to delete the current folder
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.PHOTO_MENU_DELETE_PHOTO);
+        item.activate.connect ((item) => { this.manager.delete (); });
+        item.show ();
+        menu.append (item);
 
-            item = new MenuItemSeparator();
-            item.show();
-            menu.append (item);
+        item = new MenuItemSeparator ();
+        item.show ();
+        menu.append (item);
 
-            item = new MenuItemColor(FIXO_TAGS_COLORS);
-            ((MenuItemColor)item).color_changed.connect(change_fixo_color);
-            item.show();
-            menu.append (item);
+        item = new MenuItemColor (FIXO_TAGS_COLORS);
+        ((MenuItemColor) item).color_changed.connect (change_fixo_color);
+        item.show ();
+        menu.append (item);
 
-        //}
+        // }
 
-        //finally we show the popup
-        menu.popup(
-             null //parent menu shell
-            ,null //parent menu item
-            ,null //func
-            ,event.button // button
-            ,event.get_time() //Gtk.get_current_event_time() //time
-            );
+        // finally we show the popup
+        menu.popup (
+            null  // parent menu shell
+            , null // parent menu item
+            , null // func
+            , event.button // button
+            , event.get_time () // Gtk.get_current_event_time() //time
+        );
     }
 
     /**
-    * @name change_fixo_color
-    * @description change event captured from the popup for a new color to the fixo color
-    * @param ncolor int the new color for the fixo
-    */
-    private void change_fixo_color(int ncolor){
-        this.manager.get_settings().fixocolor=ncolor;
-        //reseting fixo images
-        this.fixoPixbuf=null;
-        this.queue_draw();
+     * @name change_fixo_color
+     * @description change event captured from the popup for a new color to the fixo color
+     * @param ncolor int the new color for the fixo
+     */
+    private void change_fixo_color (int ncolor) {
+        this.manager.get_settings ().fixocolor = ncolor;
+        // reseting fixo images
+        this.fixoPixbuf = null;
+        this.queue_draw ();
     }
 
     /**
-    * @name new_desktop_folder
-    * @description show a dialog to create a new desktop folder
-    */
-    private void new_desktop_folder(){
-        DesktopFolder.Util.create_new_desktop_folder(this);
+     * @name new_desktop_folder
+     * @description show a dialog to create a new desktop folder
+     */
+    private void new_desktop_folder () {
+        DesktopFolder.Util.create_new_desktop_folder (this);
     }
 
     /**
-    * @name new_note
-    * @description show a dialog to create a new note
-    */
-    private void new_note(){
-        DesktopFolder.Util.create_new_note(this);
+     * @name new_note
+     * @description show a dialog to create a new note
+     */
+    private void new_note () {
+        DesktopFolder.Util.create_new_note (this);
     }
 
     /**
-    * @name new_photo
-    * @description show a dialog to create a new photo
-    */
-    private void new_photo(){
-        DesktopFolder.Util.create_new_photo(this);
+     * @name new_photo
+     * @description show a dialog to create a new photo
+     */
+    private void new_photo () {
+        DesktopFolder.Util.create_new_photo (this);
     }
 
     /**
-    * @name draw_backgorund
-    * @description draw the note window background intercepting the draw signal
-    * @param {Cairo.Context} cr the cairo context
-    * @bool @see draw signal
-    */
+     * @name draw_backgorund
+     * @description draw the note window background intercepting the draw signal
+     * @param {Cairo.Context} cr the cairo context
+     * @bool @see draw signal
+     */
     private bool draw_background (Cairo.Context cr) {
-        int width = this.get_allocated_width ();
+        int width  = this.get_allocated_width ();
         int height = this.get_allocated_height ();
 
         cr.set_operator (Cairo.Operator.CLEAR);
         cr.paint ();
         cr.set_operator (Cairo.Operator.OVER);
 
-        try{
-            //the image dimenssions
-            int pixwidth=width-50;
-            int pixheight=height-50;
+        try {
+            // the image dimenssions
+            int pixwidth  = width - 50;
+            int pixheight = height - 50;
 
-            //drawing the shadow
-            if(this.manager.get_settings().fixocolor==0){
-                if(this.shadowSurface==null){
-                    var shadowPixbuf=new Gdk.Pixbuf.from_resource("/com/github/spheras/desktopfolder/shadow.png");
-                    shadowPixbuf=shadowPixbuf.scale_simple(pixwidth,40,Gdk.InterpType.BILINEAR);
-                    this.shadowSurface=Gdk.cairo_surface_create_from_pixbuf(shadowPixbuf, 0, null);
+            // drawing the shadow
+            if (this.manager.get_settings ().fixocolor == 0) {
+                if (this.shadowSurface == null) {
+                    var shadowPixbuf = new Gdk.Pixbuf.from_resource ("/com/github/spheras/desktopfolder/shadow.png");
+                    shadowPixbuf       = shadowPixbuf.scale_simple (pixwidth, 40, Gdk.InterpType.BILINEAR);
+                    this.shadowSurface = Gdk.cairo_surface_create_from_pixbuf (shadowPixbuf, 0, null);
                 }
-                cr.set_source_surface (this.shadowSurface, width/2 - pixwidth/2,height/2 - pixheight/2 + pixheight-2);
-                cr.paint();
+                cr.set_source_surface (this.shadowSurface, width / 2 - pixwidth / 2, height / 2 - pixheight / 2 + pixheight - 2);
+                cr.paint ();
             }
 
-            //the photo
-            if(photoSurface==null){
-                var photopath=this.manager.get_settings().photo_path;
-                var photoPixbuf=new Gdk.Pixbuf.from_file(photopath);
-                photoPixbuf=photoPixbuf.scale_simple(pixwidth,pixheight,Gdk.InterpType.BILINEAR);
-                this.photoSurface=Gdk.cairo_surface_create_from_pixbuf(photoPixbuf, 0, null);
-                //DesktopFolder.Util.blur_image_surface((Cairo.ImageSurface)this.photoSurface,4);
+            // the photo
+            if (photoSurface == null) {
+                var photopath   = this.manager.get_settings ().photo_path;
+                var photoPixbuf = new Gdk.Pixbuf.from_file (photopath);
+                photoPixbuf       = photoPixbuf.scale_simple (pixwidth, pixheight, Gdk.InterpType.BILINEAR);
+                this.photoSurface = Gdk.cairo_surface_create_from_pixbuf (photoPixbuf, 0, null);
+                // DesktopFolder.Util.blur_image_surface((Cairo.ImageSurface)this.photoSurface,4);
             }
-            cr.set_source_surface (this.photoSurface, width/2 - pixwidth/2, height/2 - pixheight/2);
-            cr.paint();
+            cr.set_source_surface (this.photoSurface, width / 2 - pixwidth / 2, height / 2 - pixheight / 2);
+            cr.paint ();
 
-            //lets draw the fixo
-            int fixoWidth=56;
-            int fixoHeight=56;
-            int fixoMargin=4;
-            int fixocolor=this.manager.get_settings().fixocolor;
-            var color="";
-            switch(fixocolor){
-                case 0:
-                    color= null;
-                    break;
-                case 1:
-                    color= "banana";
-                    break;
-                case 2:
-                    color= "orange";
-                    break;
-                case 3:
-                    color= "lime";
-                    break;
-                case 4:
-                    color= "blueberry";
-                    break;
-                case 5:
-                    color= "grape";
-                    break;
-                case 6:
-                    color= "strawberry";
-                    break;
-                case 7:
-                    color= "white";
-                    break;
-                default:
-                case 8:
-                    color= "black";
-                    break;
+            // lets draw the fixo
+            int fixoWidth  = 56;
+            int fixoHeight = 56;
+            int fixoMargin = 4;
+            int fixocolor  = this.manager.get_settings ().fixocolor;
+            var color      = "";
+            switch (fixocolor) {
+            case 0:
+                color = null;
+                break;
+            case 1:
+                color = "banana";
+                break;
+            case 2:
+                color = "orange";
+                break;
+            case 3:
+                color = "lime";
+                break;
+            case 4:
+                color = "blueberry";
+                break;
+            case 5:
+                color = "grape";
+                break;
+            case 6:
+                color = "strawberry";
+                break;
+            case 7:
+                color = "white";
+                break;
+            default:
+            case 8:
+                color = "black";
+                break;
             }
-            if(color!=null){
-                if(this.fixoPixbuf==null){
-                    this.fixoPixbuf=new Gdk.Pixbuf.from_resource("/com/github/spheras/desktopfolder/fixo-"+color+".svg");
-                    //this.fixoPixbuf=fixoPixbuf.scale_simple(100,100,Gdk.InterpType.BILINEAR);
+            if (color != null) {
+                if (this.fixoPixbuf == null) {
+                    this.fixoPixbuf = new Gdk.Pixbuf.from_resource ("/com/github/spheras/desktopfolder/fixo-" + color + ".svg");
+                    // this.fixoPixbuf=fixoPixbuf.scale_simple(100,100,Gdk.InterpType.BILINEAR);
                 }
-                var fixoSurface=Gdk.cairo_surface_create_from_pixbuf(this.fixoPixbuf, 0, null);
+                var fixoSurface = Gdk.cairo_surface_create_from_pixbuf (this.fixoPixbuf, 0, null);
                 cr.set_source_surface (fixoSurface, fixoMargin, fixoMargin);
-                cr.paint();
+                cr.paint ();
 
-                var rotatedPixbuf=this.fixoPixbuf.rotate_simple(Gdk.PixbufRotation.COUNTERCLOCKWISE);
-                fixoSurface=Gdk.cairo_surface_create_from_pixbuf(rotatedPixbuf, 0, null);
-                cr.set_source_surface (fixoSurface, width-fixoWidth - fixoMargin, fixoMargin);
-                cr.paint();
+                var rotatedPixbuf = this.fixoPixbuf.rotate_simple (Gdk.PixbufRotation.COUNTERCLOCKWISE);
+                fixoSurface = Gdk.cairo_surface_create_from_pixbuf (rotatedPixbuf, 0, null);
+                cr.set_source_surface (fixoSurface, width - fixoWidth - fixoMargin, fixoMargin);
+                cr.paint ();
 
-                rotatedPixbuf=rotatedPixbuf.rotate_simple(Gdk.PixbufRotation.COUNTERCLOCKWISE);
-                fixoSurface=Gdk.cairo_surface_create_from_pixbuf(rotatedPixbuf, 0, null);
-                cr.set_source_surface (fixoSurface, width-fixoWidth - fixoMargin, height-fixoHeight - fixoMargin);
-                cr.paint();
+                rotatedPixbuf = rotatedPixbuf.rotate_simple (Gdk.PixbufRotation.COUNTERCLOCKWISE);
+                fixoSurface   = Gdk.cairo_surface_create_from_pixbuf (rotatedPixbuf, 0, null);
+                cr.set_source_surface (fixoSurface, width - fixoWidth - fixoMargin, height - fixoHeight - fixoMargin);
+                cr.paint ();
 
-                rotatedPixbuf=rotatedPixbuf.rotate_simple(Gdk.PixbufRotation.COUNTERCLOCKWISE);
-                fixoSurface=Gdk.cairo_surface_create_from_pixbuf(rotatedPixbuf, 0, null);
-                cr.set_source_surface (fixoSurface, fixoMargin, height-fixoHeight - fixoMargin);
-                cr.paint();
+                rotatedPixbuf = rotatedPixbuf.rotate_simple (Gdk.PixbufRotation.COUNTERCLOCKWISE);
+                fixoSurface   = Gdk.cairo_surface_create_from_pixbuf (rotatedPixbuf, 0, null);
+                cr.set_source_surface (fixoSurface, fixoMargin, height - fixoHeight - fixoMargin);
+                cr.paint ();
             }
 
         } catch (Error e) {
-            //error! ??
+            // error! ??
             stderr.printf ("Error: %s\n", e.message);
         }
 

--- a/src/widgets/ProgressDialog.vala
+++ b/src/widgets/ProgressDialog.vala
@@ -1,20 +1,20 @@
-public class DesktopFolder.ProgressDialog : Gtk.Dialog{
+public class DesktopFolder.ProgressDialog : Gtk.Dialog {
     private Gtk.Widget status;
     private Gtk.Widget progress_bar;
     private Gtk.Box window_vbox;
-    private uint timeout_id =0;
+    private uint timeout_id = 0;
     private GLib.Cancellable cancellable;
 
     /**
-    * @constructor
-    * @param FolderManager manager the manager of this window
-    */
-    public ProgressDialog (string title, Gtk.Window? parent){
-        this.resizable = false;
-        this.deletable = false;
-        this.title = title;
+     * @constructor
+     * @param FolderManager manager the manager of this window
+     */
+    public ProgressDialog (string title, Gtk.Window ? parent) {
+        this.resizable   = false;
+        this.deletable   = false;
+        this.title       = title;
 
-        this.icon_name = "system-file-manager";
+        this.icon_name   = "system-file-manager";
         this.window_vbox = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
         this.get_content_area ().set_border_width (10);
         this.get_content_area ().add (window_vbox);
@@ -22,8 +22,8 @@ public class DesktopFolder.ProgressDialog : Gtk.Dialog{
 
         this.status = new Gtk.Label (title);
         (this.status as Gtk.Label).set_size_request (500, -1);
-        (this.status as Gtk.Label).set_max_width_chars(50);
-        (this.status as Gtk.Label).set_ellipsize(Pango.EllipsizeMode.MIDDLE);
+        (this.status as Gtk.Label).set_max_width_chars (50);
+        (this.status as Gtk.Label).set_ellipsize (Pango.EllipsizeMode.MIDDLE);
         (this.status as Gtk.Label).set_line_wrap (true);
         (this.status as Gtk.Label).set_line_wrap_mode (Pango.WrapMode.WORD_CHAR);
         (this.status as Gtk.Misc).set_alignment ((float) 0.0, (float) 0.5);
@@ -31,36 +31,36 @@ public class DesktopFolder.ProgressDialog : Gtk.Dialog{
 
         var window_hbox = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 2);
         this.progress_bar = new Gtk.ProgressBar ();
-        window_hbox.pack_start(this.progress_bar, true, true, 0);
+        window_hbox.pack_start (this.progress_bar, true, true, 0);
         var button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.BUTTON);
         button.get_style_context ().add_class ("flat");
         button.clicked.connect (() => {
             button.sensitive = false;
-            this.cancellable.cancel();
-            this.stop();
+            this.cancellable.cancel ();
+            this.stop ();
         });
-        window_hbox.pack_start(button,false,false,0);
-        this.window_vbox.pack_start(window_hbox);
+        window_hbox.pack_start (button, false, false, 0);
+        this.window_vbox.pack_start (window_hbox);
 
         this.set_transient_for (parent);
-        this.show_all();
+        this.show_all ();
     }
 
     /**
-    * @name start
-    * @description start the progress dialog
-    */
-    public GLib.Cancellable start(){
-        this.cancellable=new GLib.Cancellable();
+     * @name start
+     * @description start the progress dialog
+     */
+    public GLib.Cancellable start () {
+        this.cancellable = new GLib.Cancellable ();
         this.cancellable.cancelled.connect (() => {
-			this.stop();
-		});
+            this.stop ();
+        });
 
-        this.show();
-        this.timeout_id=GLib.Timeout.add(100, ()=>{
-            //this.prueba.set_text("prueba %d".printf(this.index));
-            (this.progress_bar as Gtk.ProgressBar).pulse();
-            (this.status as Gtk.Label).set_text(this.text);
+        this.show ();
+        this.timeout_id = GLib.Timeout.add (100, () => {
+            // this.prueba.set_text("prueba %d".printf(this.index));
+            (this.progress_bar as Gtk.ProgressBar).pulse ();
+            (this.status as Gtk.Label).set_text (this.text);
             return true;
         });
 
@@ -68,26 +68,27 @@ public class DesktopFolder.ProgressDialog : Gtk.Dialog{
     }
 
     /**
-    * @name stop
-    * @description stop the progres bar
-    */
-    public void stop(){
+     * @name stop
+     * @description stop the progres bar
+     */
+    public void stop () {
         if (this.timeout_id > 0) {
             GLib.Source.remove (this.timeout_id);
             this.timeout_id = 0;
         }
-        this.close();
+        this.close ();
     }
 
-    string text="";
+    string text = "";
 
     /**
-    * @name show_action
-    * @description show the action in the progress dialog
-    * @param {string} action the action to be showed
-    */
-    public void show_action(string action){
-        text=action;
-        debug(action);
+     * @name show_action
+     * @description show the action in the progress dialog
+     * @param {string} action the action to be showed
+     */
+    public void show_action (string action) {
+        text = action;
+        debug (action);
     }
+
 }


### PR DESCRIPTION
- Ran clean up script on code (based on [elementary's code style guidelines](https://elementary.io/docs/code/reference#code-style)).
- Made some manual formatting edits
- Slightly edited one or two comments
- Corrected `clean_shortchut ()` to `clean_shortcut ()`
- (Panels and Notes) Renamed `delete ()` to `trash ()` which is what it actually does (`delete ()` is to be added)
  - (Photos) Made PhotoManager `delete ()` actually delete the .dfp file (it's easy to add the photo back onto the desktop).
- Lessened repetition of `on_key` event in FolderWindow
- Added `trash ()` to ItemView which simply forwards to the ItemManager's `trash ()`

The large majority of the line changes are from the code formatting script.

This will probably not merge nicely with any other changes or branches because of the large amount of line changes.