### PR TITLE
Fix segmentation fault

### DIFF
--- a/src/settings/PhotoSettings.vala
+++ b/src/settings/PhotoSettings.vala
@@ -3,8 +3,8 @@ public class DesktopFolder.PhotoSettings : Object {
     public int    y  { get; set; default = 0; }
     public int    w  { get; set; default = 0; }
     public int    h  { get; set; default = 0; }
-    public int    original_width;
-    public int    original_height;
+    public int    original_width { get; set; default = 0; }
+    public int    original_height { get; set; default = 0; }
     public int    fixocolor { get; set; default = 0; }
     public string name { get; set; }
     public string photo_path { get; set; }

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -149,22 +149,31 @@ namespace DesktopFolder.Util {
 
         // Process response:
         if (chooser.run () == Gtk.ResponseType.ACCEPT) {
-            var           photo_path = chooser.get_filename ();
-            PhotoSettings ps         = new PhotoSettings (photo_path);
-            string        path       = DesktopFolderApp.get_app_folder () + "/" + ps.name + "." + DesktopFolder.PHOTO_EXTENSION;
-            File          file       = File.new_for_path (path);
-            if (file.query_exists ()) {
-                // string message = "Can't create photo, photo already exists.";
-                // Gtk.MessageDialog msg = new Gtk.MessageDialog (window, Gtk.DialogFlags.MODAL,
-                // Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, message);
-                debug ("Photo already exists, not creating.");
-                // msg.response.connect ((response_id) => {
-                // msg.destroy ();
-                // });
-                // msg.set_deletable (false);
-                // msg.show ();
-            } else {
-                ps.save_to_file (file);
+            var photo_path = chooser.get_filename ();
+            debug ("Photo path: " + photo_path);
+            
+            try {
+                // Check if the image is valid
+                Gdk.Pixbuf check_photo   = new Gdk.Pixbuf.from_file (photo_path);
+                
+                PhotoSettings ps         = new PhotoSettings (photo_path);
+                string        path       = DesktopFolderApp.get_app_folder () + "/" + ps.name + "." + DesktopFolder.PHOTO_EXTENSION;
+                File          file       = File.new_for_path (path);
+                if (file.query_exists ()) {
+                    // string message = "Can't create photo, photo already exists.";
+                    // Gtk.MessageDialog msg = new Gtk.MessageDialog (window, Gtk.DialogFlags.MODAL,
+                    // Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, message);
+                    debug ("Photo already exists, not creating.");
+                    // msg.response.connect ((response_id) => {
+                    // msg.destroy ();
+                    // });
+                    // msg.set_deletable (false);
+                    // msg.show ();
+                } else {
+                    ps.save_to_file (file);
+                }
+            } catch {
+                debug ("Invalid photo: " + photo_path);
             }
         }
         chooser.close ();


### PR DESCRIPTION
- Fixes segmentation fault from unset variables
- Prevents creating an invalid photo in the first place

This doesn't fix the fact that PhotoSettings isn't checked at all if it returns `null`.