### PR TITLE
Add libjson-glib-dev to dependency list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You'll need the following dependencies to build:
 * libgdk-pixbuf2.0-dev
 * libwnck-3-dev
 * libgtksourceview-3.0-dev
+* libjson-glib-dev
 * meson
 * valac
 


### PR DESCRIPTION
Closes #83.