### PR TITLE
Add a meson option to set the executable name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,8 +64,10 @@ src = [
        'src/dialogs/PanelPropertiesWindow.vala'
       ]
 
+exename = get_option('exename')
+
 executable(
-    'com.github.spheras.desktopfolder',
+    exename,
     src,
     asresources,
     c_args: c_args,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('exename', type : 'string', value : 'com.github.spheras.desktopfolder', description : 'executable name')


### PR DESCRIPTION
From issue #119 this adds an option to allow the compiler to define the executable name.

So the default is the standard elementary exe name  - name change for elementary

For everyone else, they can use `meson configure -Dexename=newname` to override the executable name