### PR TITLE
Allow desktop configuration apps to stop showing desktopfolder #126

### DIFF
--- a/data/com.github.spheras.desktopfolder.gschema.xml
+++ b/data/com.github.spheras.desktopfolder.gschema.xml
@@ -24,5 +24,10 @@
       <summary>Create first folder</summary>
       <description>When first run create an initial folder on the desktop</description>
     </key>
+    <key name="show-desktopfolder" type="b">
+      <default>true</default>
+      <summary>Have DesktopFolder handle the desktop</summary>
+      <description>If set false, DesktopFolder will exit gracefully on startup or when running</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -29,6 +29,7 @@ public class DesktopFolderApp : Gtk.Application {
 
     /** schema settings */
     private GLib.Settings settings = null;
+    private const string SHOW_DESKTOPFOLDER_KEY = "show-desktopfolder";
 
     /** List of folder owned by the application */
     private DesktopFolder.DesktopManager desktop       = null;
@@ -113,6 +114,10 @@ public class DesktopFolderApp : Gtk.Application {
         // define our settings schema
         settings = new GLib.Settings ("com.github.spheras.desktopfolder");
 
+        // Connect to show-desktopfolder key
+        settings.changed[SHOW_DESKTOPFOLDER_KEY].connect (on_show_desktopfolder_changed);
+        on_show_desktopfolder_changed();
+
         create_shortcut ();
 
         // we need the app folder (desktop folder)
@@ -162,6 +167,17 @@ public class DesktopFolderApp : Gtk.Application {
         });
     }
 
+    /**
+     * @name on_show_desktopfolder_changed
+     * @description detect when desktopfolder key is toggled
+     */
+    private void on_show_desktopfolder_changed () {
+        bool show_desktopfolder = settings.get_boolean(SHOW_DESKTOPFOLDER_KEY);
+        if (!show_desktopfolder) {
+            // requested to no longer show the desktop so let's gracefully quit
+            this.quit ();
+        }
+    }
     /**
      * @name on_mount_changed
      * @description event to detect when the mount file system has been changed, probably we need to recheck files existence


### PR DESCRIPTION
this PR resolves #126 

Simple test:

1. check that the default install, desktopfolder starts up ok ---> yes it does
2. Toggle off the new schema key when desktopfolder is running --> desktopfolder quits without error on the command line
3. Start desktopfolder when the new schema key is toggled off --> desktopfolder immediately quits without error.