### PR TITLE
Open folder in terminal

### DIFF
--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -192,4 +192,6 @@ namespace DesktopFolder.Lang {
     public const string DESKTOPFOLDER_MENU_CHANGEDESKTOP                = _("Change Wallpaper");
     // open terminal here
     public const string DESKTOPFOLDER_MENU_OPENTERMINAL                 = _("Open terminal here");
+    // open terminal here
+    public const string DESKTOPFOLDER_MENU_OPEN_IN_TERMINAL                 = _("Open in terminal");
 }

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -323,8 +323,13 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @description open terminal here, works in folder & on Desktop
      */
     public void open_terminal_here (string path) {
-        Environment.set_current_dir (path);
-        Process.spawn_command_line_async ("x-terminal-emulator");
+        try {
+            Environment.set_current_dir (path);
+            Process.spawn_command_line_async ("x-terminal-emulator --working-directory \"" + path + "\"");
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            Util.show_error_dialog ("Error", e.message);
+        }
     }
 
     /**

--- a/src/logic/ItemManager.vala
+++ b/src/logic/ItemManager.vala
@@ -227,6 +227,16 @@ public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.Cl
         return false;
     }
 
+    public void open_in_terminal (string path) {
+        try {
+            Environment.set_current_dir (path);
+            Process.spawn_command_line_async ("x-terminal-emulator --working-directory \"" + path + "\"");
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            Util.show_error_dialog ("Error", e.message);
+        }
+    }
+
     /**
      * @name execute
      * @description execute the file associated with this item

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -583,6 +583,7 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
      * @param EventButton event the event button that originates this context menu
      */
     private void show_popup (Gdk.EventButton event) {
+
         // debug("evento:%f,%f",event.x,event.y);
         // if(this.menu==null) { //we need the event coordinates for the menu, we need to recreate?!
 
@@ -642,6 +643,19 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         item.show ();
         menu.append (item);
         // }
+
+        // only add open-folder-in-terminal to menu if the item is a folder
+        if (this.manager.is_folder ()) {
+            string open_folderpath = this.manager.get_absolute_path();
+            item = new MenuItemSeparator ();
+            item.show ();
+            menu.append (item);
+
+            item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_OPEN_IN_TERMINAL);
+            item.activate.connect ((item) => { this.manager.open_in_terminal (path); });
+            item.show ();
+            menu.append (item);
+        }
 
         menu.show_all ();
         // }


### PR DESCRIPTION
An extension of the previous "Open terminal here" right-click option. This one adds a conditional menu item (if the item is a folder): "Open in terminal". 

![afbeelding](https://user-images.githubusercontent.com/8932980/48499694-4ac4ee00-e839-11e8-90ad-608a5b62bfec.png)
