### PR TITLE
Replace naming dialogs with rename in place

### DIFF
--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -214,5 +214,10 @@ namespace DesktopFolder.Lang {
     // force panels to be organized automatically one time
     public const string DESKTOPFOLDER_MENU_SORT_ORGANIZE = _("Force Reorganization");
 
+    // the title of a panel when a new one is created
+    public const string NEWLY_CREATED_PANEL = _("Untitled Panel");
+    // the title of a note when a new one is created
+    public const string NEWLY_CREATED_NOTE = _("New Note");
+
 
 }

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -79,13 +79,13 @@ namespace DesktopFolder.Lang {
     // desktopfolder - Dialog Text to ask the new name for a folder inside a Desktop-Folder
     public const string DESKTOPFOLDER_NEW_FOLDER_MESSAGE         = _("Enter the name");
     // desktopfolder - The default name for the new folder to be created
-    public const string DESKTOPFOLDER_NEW_FOLDER_NAME            = _("new folder");
+    public const string DESKTOPFOLDER_NEW_FOLDER_NAME            = _("untitled folder");
     // desktopfolder - Dialog Title to ask the new name for a text file inside a Desktop-Folder
     public const string DESKTOPFOLDER_NEW_TEXT_FILE_TITLE        = _("New Text File");
     // desktopfolder - Dialog Text to ask the new name for a text file inside a Desktop-Folder
     public const string DESKTOPFOLDER_NEW_TEXT_FILE_MESSAGE      = _("Enter the name");
     // desktopfolder - The default name for the new text file to be created
-    public const string DESKTOPFOLDER_NEW_TEXT_FILE_NAME         = _("new.txt");
+    public const string DESKTOPFOLDER_NEW_TEXT_FILE_NAME         = _("new file");
     // desktopfolder - The message to confirm the deletion of a Desktop Folder
     public const string DESKTOPFOLDER_DELETE_TOOLTIP             = _("Move to Trash");
     // desktopfolder - The message to confirm the deletion of a Desktop Folder

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -472,7 +472,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @param int x the x position of the new folder
      * @param int y the y position of the new folder
      */
-    public string create_new_folder (int x, int y, string name = "untitled folder") {
+    public string create_new_folder (int x, int y, string name = DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_NAME) {
         string path = this.get_absolute_path () + "/" + name;
 
         string new_name = "";
@@ -504,7 +504,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @param int x the x position of the new file
      * @param int y the y position of the new file
      */
-    public string create_new_text_file (int x, int y, string name = "new file") {
+    public string create_new_text_file (int x, int y, string name = DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_NAME) {
         string path = this.get_absolute_path () + "/" + name;
 
         string new_name = "";

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -120,6 +120,21 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
         }
     }
 
+
+    /**
+     * @name get_item_by_filename
+     * @description get item by filename, or null if none
+     * @param string filename to get item for, null if none
+     */
+    public ItemManager ? get_item_by_filename (string name) {
+        foreach (ItemManager item in this.items) {
+            if (item.get_file_name() == name) {
+                return item;
+            }
+        }
+        return null;
+    }
+
     /**
      * @name set_selected_item
      * @description set the selected item
@@ -457,10 +472,20 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @param int x the x position of the new folder
      * @param int y the y position of the new folder
      */
-    public void create_new_folder (string name, int x, int y) {
+    public string create_new_folder (int x, int y, string name = "untitled folder") {
+        string path = this.get_absolute_path () + "/" + name;
+
+        string new_name = "";
+
+        File folder = File.new_for_path (path);
+        if (folder.query_exists ()) {
+            new_name = DesktopFolder.Util.make_next_duplicate_name (name, this.get_absolute_path ());
+        } else {
+            new_name = name;
+        }
         // cancelling the current monitor
         this.monitor.cancel ();
-        string folder_path = this.get_absolute_path () + "/" + name;
+        string folder_path = this.get_absolute_path () + "/" + new_name;
         DirUtils.create (folder_path, 0755);
 
         this.create_new_folder_inside (folder_path);
@@ -468,6 +493,8 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
         this.sync_files (x, y);
         // monitoring again
         this.monitor_folder ();
+
+        return new_name;
     }
 
     /**

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -504,7 +504,18 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @param int x the x position of the new file
      * @param int y the y position of the new file
      */
-    public void create_new_text_file (string name, int x, int y) {
+    public string create_new_text_file (int x, int y, string name = "new file") {
+        string path = this.get_absolute_path () + "/" + name;
+
+        string new_name = "";
+
+        File folder = File.new_for_path (path);
+        if (folder.query_exists ()) {
+            new_name = DesktopFolder.Util.make_next_duplicate_name (name, this.get_absolute_path ());
+        } else {
+            new_name = name;
+        }
+
         // cancelling the current monitor
         this.monitor.cancel ();
 
@@ -522,6 +533,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
             stderr.printf ("Error: %s\n", e.message);
             Util.show_error_dialog ("Error", e.message);
         }
+        return new_name;
     }
 
     /**

--- a/src/settings/FolderSettings.vala
+++ b/src/settings/FolderSettings.vala
@@ -186,6 +186,18 @@ public class DesktopFolder.FolderSettings : PositionSettings {
             }
         }
     }
+
+    private bool _edit_label_on_creation;
+    public bool edit_label_on_creation {
+        get {
+            return _edit_label_on_creation;
+        }
+        set {
+            if (_edit_label_on_creation != value) {
+                _edit_label_on_creation = value; flagChanged = true;
+            }
+        }
+    }
     // default json seralization implementation only support primitive types
 
     private File file;
@@ -218,6 +230,7 @@ public class DesktopFolder.FolderSettings : PositionSettings {
         this.name             = name;
         this.items            = new string[0];
         this.version          = DesktopFolder.SETTINGS_VERSION;
+        this.edit_label_on_creation = false;
         check_off_screen ();
     }
 
@@ -442,7 +455,7 @@ public class DesktopFolder.FolderSettings : PositionSettings {
         List <ItemSettings> all = new List <ItemSettings> ();
         for (int i = 0; i < this.items.length; i++) {
             ItemSettings is = ItemSettings.parse (this.items[i]);
-            var basePath = Environment.get_home_dir () + "/Desktop/" + this.name;
+            var basePath = Environment.get_home_dir () + "/Desktop" + this.name;
             var filepath = basePath + "/" + is.name;
             // debug("checking:"+filepath);
             File f       = File.new_for_path (filepath);

--- a/src/settings/FolderSettings.vala
+++ b/src/settings/FolderSettings.vala
@@ -455,7 +455,7 @@ public class DesktopFolder.FolderSettings : PositionSettings {
         List <ItemSettings> all = new List <ItemSettings> ();
         for (int i = 0; i < this.items.length; i++) {
             ItemSettings is = ItemSettings.parse (this.items[i]);
-            var basePath = Environment.get_home_dir () + "/Desktop" + this.name;
+            var basePath = Environment.get_home_dir () + "/Desktop/" + this.name;
             var filepath = basePath + "/" + is.name;
             // debug("checking:"+filepath);
             File f       = File.new_for_path (filepath);

--- a/src/settings/NoteSettings.vala
+++ b/src/settings/NoteSettings.vala
@@ -119,11 +119,25 @@ public class DesktopFolder.NoteSettings : PositionSettings {
         }
     }
 
+    private bool _edit_label_on_creation;
+    public bool edit_label_on_creation {
+        get {
+            return _edit_label_on_creation;
+        }
+        set {
+            if (_edit_label_on_creation != value) {
+                _edit_label_on_creation = value; flagChanged = true;
+            }
+        }
+    }
+
     private File file;
 
     public NoteSettings (string name) {
         this.x         = 110;
         this.y         = 110;
+        this.w         = 300;
+        this.h         = 300;
         this.bgcolor   = "df_yellow";
         this.fgcolor   = "df_dark";
         this.texture   = "";

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -247,6 +247,39 @@ namespace DesktopFolder.Util {
     }
 
     /**
+     * @name make_next_duplicate_name
+     * @description find a new name for the file
+     * @param {string} the base name to check if its repeated
+     * @param {string} the path for the file
+     * @return {string} the base name if it is ok, or a new one if not
+     */
+    public static string make_next_duplicate_name (string basename, string path) {
+        // TODO: Copy elementary's way of doing it
+        string name        = DesktopFolder.Util.sanitize_name (basename);
+        int ext_pos        = name.last_index_of (".");
+        string ext         = "";
+        string name_no_ext = name;
+        if (ext_pos != -1) {
+            ext         = name.substring (ext_pos + 1);
+            name_no_ext = name.replace (ext, "");
+        }
+        string file_to_check = "";
+
+        for (int i = 2; i < 1000000; i++) {
+            file_to_check = name_no_ext + " " + i.to_string () + ext;
+            File file = File.new_for_path (path + file_to_check);
+            if (file.query_exists ()) {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        debug ("name: " + name + ", ext_pos: " + ext_pos.to_string () + ", ext: " + ext + ", name_no_ext: " + name_no_ext + ", file_to_check: " + file_to_check);
+        return file_to_check;
+    }
+
+    /**
      * @name get_a_no_repeated_file_name
      * @description check if the name is repeated or not
      * @param {string} the base name to check if its repeated

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -1060,17 +1060,17 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      * @param int y the y position where the new folder icon should be generated
      */
     protected void new_folder (int x, int y) {
-        RenameDialog dialog = new RenameDialog (this,
-                DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_TITLE,
-                DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_MESSAGE,
-                DesktopFolder.Lang.DESKTOPFOLDER_NEW_FOLDER_NAME);
-        dialog.on_rename.connect ((new_name) => {
-            // creating the folder
-            if (new_name != "") {
-                this.manager.create_new_folder (new_name, x, y);
-            }
-        });
-        dialog.show_all ();
+        string new_name = this.manager.create_new_folder (x, y);
+        var item = this.manager.get_item_by_filename (new_name);
+        if (item == null) {
+            stderr.printf ("Error: Couldn't find the newly created folder's item.");
+            Util.show_error_dialog ("Error:", "Couldn't find the newly created folder's item.");
+            return;
+        } else {
+            ItemView itemview = item.get_view ();
+
+            itemview.start_editing ();
+        }
     }
 
     /**

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -1069,7 +1069,10 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         } else {
             ItemView itemview = item.get_view ();
 
-            itemview.start_editing ();
+            GLib.Timeout.add (50, () => {
+                itemview.start_editing ();
+                return false;
+            });
         }
     }
 
@@ -1088,14 +1091,16 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
             return;
         } else {
             ItemView itemview = item.get_view ();
-
-            itemview.start_editing ();
+            GLib.Timeout.add (50, () => {
+                itemview.start_editing ();
+                return false;
+            });
         }
     }
 
     /**
      * @name new_link
-     * @description create a new linnk item inside this folder
+     * @description create a new link item inside this folder
      * @param int x the x position where the new item should be placed
      * @param int y the y position where the new item should be placed
      * @param bool folder to indicate if we want to select a folder or a file

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -1080,16 +1080,17 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      * @param int y the y position where the new item should be placed
      */
     protected void new_text_file (int x, int y) {
-        RenameDialog dialog = new RenameDialog (this,
-                DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_TITLE,
-                DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_MESSAGE,
-                DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_NAME);
-        dialog.on_rename.connect ((new_name) => {
-            if (new_name != "") {
-                this.manager.create_new_text_file (new_name, x, y);
-            }
-        });
-        dialog.show_all ();
+        string new_name = this.manager.create_new_text_file (x, y);
+        var item = this.manager.get_item_by_filename (new_name);
+        if (item == null) {
+            stderr.printf ("Error: Couldn't find the newly created folder's item.");
+            Util.show_error_dialog ("Error:", "Couldn't find the newly created folder's item.");
+            return;
+        } else {
+            ItemView itemview = item.get_view ();
+
+            itemview.start_editing ();
+        }
     }
 
     /**

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -182,6 +182,17 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
 
 
         // TODO this.dnd_behaviour=new DragnDrop.DndBehaviour(this,false, true);
+
+        FolderSettings settings = this.manager.get_settings ();
+
+        debug (settings.edit_label_on_creation.to_string ());
+        if (settings.edit_label_on_creation) {
+            GLib.Timeout.add (50, () => {
+                this.label.start_editing ();
+                settings.edit_label_on_creation = false;
+                return false;
+            });
+        }
     }
 
     /**
@@ -280,10 +291,10 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         }
         this.get_style_context ().add_class (settings.fgcolor);
 
-        if (this.manager.get_settings ().textshadow) {
+        if (settings.textshadow) {
             this.get_style_context ().add_class ("df_shadow");
         }
-        if (this.manager.get_settings ().textbold) {
+        if (settings.textbold) {
             this.get_style_context ().add_class ("df_bold");
         }
 

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -135,6 +135,16 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
         // TODO: Does the GTK window have any active signal or css :active state?
         Wnck.Screen screen = Wnck.Screen.get_default ();
         screen.active_window_changed.connect (on_active_change);
+
+        NoteSettings settings = this.manager.get_settings ();
+
+        if (settings.edit_label_on_creation) {
+            GLib.Timeout.add (0, () => {
+                this.label.start_editing ();
+                settings.edit_label_on_creation = false;
+                return false;
+            });
+        }
     }
 
 
@@ -149,7 +159,8 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
         header.height_request = DesktopFolder.HEADERBAR_HEIGHT;
         header.has_subtitle   = false;
         this.label            = new DesktopFolder.EditableLabel (manager.get_note_name ());
-        this.label.set_margin_end (15);
+        this.label.set_margin_top (10);
+        this.label.set_margin_end (40);
         this.label.show_popup.connect ((event) => { this.show_popup (event); return true; });
         this.label.get_style_context ().add_class ("title");
         header.set_custom_title (this.label);


### PR DESCRIPTION
Fixes #162 

- Instead of showing the naming dialog, the application now creates panels, notes and files/folders and automatically triggers the editing of the label.
- Duplicate naming is handled.
- Copy and paste a file in the same directory will now create a copy (uses same duplicate naming function).
- Misc additional fixes and typo corrections.

Problems:
- Is FolderManager's new function `get_item_by_filename` a suitable way of doing what I intended to do or is there a better way?
- The triggering of the editable label for notes isn't working quite correctly. I'm not sure what is causing it.