### PR TITLE
Handle lack of trailing slash on path in duplicate file handling code

### DIFF
--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -526,12 +526,12 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @param int y the y position of the new file
      */
     public string create_new_text_file (int x, int y, string name = DesktopFolder.Lang.DESKTOPFOLDER_NEW_TEXT_FILE_NAME) {
-        string path     = this.get_absolute_path () + "/" + name;
+        string path = this.get_absolute_path () + "/" + name;
 
         string new_name = "";
 
-        File folder     = File.new_for_path (path);
-        if (folder.query_exists ()) {
+        File file = File.new_for_path (path);
+        if (file.query_exists ()) {
             new_name = DesktopFolder.Util.make_next_duplicate_name (name, this.get_absolute_path ());
         } else {
             new_name = name;

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -238,7 +238,11 @@ namespace DesktopFolder.Util {
      */
     public static string make_next_duplicate_name (string basename, string path) {
         // TODO: Copy elementary's way of doing it
-        string name        = DesktopFolder.Util.sanitize_name (basename);
+        string new_path = sanitize_name (path);
+        if (!new_path.has_suffix ("/")) {
+            new_path += "/";
+        }
+        string name        = sanitize_name (basename);
         int    ext_pos     = name.last_index_of (".");
         string ext         = "";
         string name_no_ext = name;
@@ -247,14 +251,13 @@ namespace DesktopFolder.Util {
             name_no_ext = name.replace (ext, "");
             name_no_ext = name_no_ext.strip ();
         }
+
         string new_filename = "";
 
         for (int i = 2; i < 1000000; i++) {
-            new_filename = name_no_ext + " " + i.to_string ();
-            File file = File.new_for_path (path + new_filename + ext);
-            if (file.query_exists ()) {
-                continue;
-            } else {
+            new_filename = @"$name_no_ext $i";
+            File file = File.new_for_path (new_path + new_filename + ext);
+            if (!file.query_exists ()) {
                 break;
             }
         }


### PR DESCRIPTION
Fixes #181

`make_next_duplicate_name` in Utils now handles paths without a trailing slash.