### PR TITLE
Small improvements and cleanups

### DIFF
--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -218,5 +218,7 @@ namespace DesktopFolder.Lang {
     public const string NEWLY_CREATED_PANEL              = _("Untitled Panel");
     // the title of a note when a new one is created
     public const string NEWLY_CREATED_NOTE               = _("New Note");
+    /// Please keep $FILE_NAME, it will be replaced by it's value
+    public const string LINK_TO                          = _("Link to $FILE_NAME");
 
 }

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -122,6 +122,8 @@ namespace DesktopFolder.Lang {
     public const string ITEM_MENU_COPY             = _("Copy");
     // Item Menu - rename the file/folder
     public const string ITEM_MENU_RENAME           = _("Rename");
+    // Item Menu - trash the file/folder
+    public const string ITEM_MENU_TRASH            = _("Move to Trash");
     // Item Menu - delete the file/folder
     public const string ITEM_MENU_DELETE           = _("Delete");
     // Item Menu - change icon

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -203,7 +203,7 @@ namespace DesktopFolder.Lang {
 
 
     // sort by submenu
-    public const string DESKTOPFOLDER_MENU_SORT_BY       = _("Sort By");
+    public const string DESKTOPFOLDER_MENU_SORT_BY       = _("Sort by");
     // sort panel's items by name
     public const string DESKTOPFOLDER_MENU_SORT_BY_NAME  = _("Name");
     // sort panel's items by size

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -199,9 +199,7 @@ namespace DesktopFolder.Lang {
     // Managed arrangement
     public const string PANELPROPERTIES_ARRANGEMENT_MANAGED             = _("Let app manage");
     // Default Panel Management
-    public const string PANELPROPERTIES_ARRANGEMENT_DEFAULT             = _("Default Arrangement:");
-    // panel properties - Default Panel Management Description
-    public const string PANELPROPERTIES_ARRANGEMENT_DEFAULT_DESCRIPTION = _("Select the Default Arrangement Method for New Panels");
+    public const string PANELPROPERTIES_ARRANGEMENT_DEFAULT             = _("Default icon arrangement:");
 
 
     // sort by submenu

--- a/src/dialogs/PanelPropertiesWindow.vala
+++ b/src/dialogs/PanelPropertiesWindow.vala
@@ -277,12 +277,6 @@ namespace DesktopFolder.Dialogs {
             arrangement_combo.margin_end = 8;
             general_grid.attach (arrangement_combo, 1, 4, 1, 1);
 
-            var arrangement_help = new Gtk.Image.from_icon_name ("help-info-symbolic", Gtk.IconSize.BUTTON);
-            arrangement_help.halign       = Gtk.Align.START;
-            arrangement_help.hexpand      = true;
-            arrangement_help.tooltip_text = DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_DEFAULT_DESCRIPTION;
-            general_grid.attach (arrangement_help, 2, 4, 1, 1);
-
             return general_grid;
         }
 

--- a/src/dialogs/PanelPropertiesWindow.vala
+++ b/src/dialogs/PanelPropertiesWindow.vala
@@ -267,8 +267,6 @@ namespace DesktopFolder.Dialogs {
             resolution_strategy_help.tooltip_text = DesktopFolder.Lang.PANELPROPERTIES_RESOLUTION_STRATEGY_DESCRIPTION;
             general_grid.attach (resolution_strategy_help, 2, 3, 1, 1);
 
-            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_RESOLUTION_STRATEGY), 0, 3, 1, 1);
-
             // DEFAULT Panel Arrangement
             general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_DEFAULT), 0, 4, 1, 1);
             var arrangement_combo = new Gtk.ComboBoxText ();

--- a/src/dialogs/PanelPropertiesWindow.vala
+++ b/src/dialogs/PanelPropertiesWindow.vala
@@ -156,25 +156,31 @@ namespace DesktopFolder.Dialogs {
             general_grid.attach (settings_switch, 1, 2, 1, 1);
             settings_switch.set_active (this.manager.get_settings ().lockitems);
             settings_switch.notify["active"].connect (this.window.on_toggle_lockitems);
-            // lock panel
-            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.DESKTOPFOLDER_MENU_LOCK_PANEL), 0, 3, 1, 1);
-            settings_switch = new SettingsSwitch ("lock_panel");
-            general_grid.attach (settings_switch, 1, 3, 1, 1);
-            settings_switch.set_active (this.manager.get_settings ().lockpanel);
-            settings_switch.notify["active"].connect (this.window.on_toggle_lockpanel);
+
+            int top_offset = -1;
+
+            if (this.window.get_type () != typeof (DesktopFolder.DesktopWindow)) {
+                top_offset = 0;
+                // lock panel
+                general_grid.attach (new SettingsLabel (DesktopFolder.Lang.DESKTOPFOLDER_MENU_LOCK_PANEL), 0, 3, 1, 1);
+                settings_switch = new SettingsSwitch ("lock_panel");
+                general_grid.attach (settings_switch, 1, 3, 1, 1);
+                settings_switch.set_active (this.manager.get_settings ().lockpanel);
+                settings_switch.notify["active"].connect (this.window.on_toggle_lockpanel);
+            }
 
             // The interface section
-            general_grid.attach (new SettingsHeader (DesktopFolder.Lang.PANELPROPERTIES_APPEARANCE), 0, 4, 2, 1);
+            general_grid.attach (new SettingsHeader (DesktopFolder.Lang.PANELPROPERTIES_APPEARANCE), 0, 4 + top_offset, 2, 1);
             // Tet shadow
             settings_switch = new SettingsSwitch ("text_shadow");
-            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_SHADOW), 0, 5, 1, 1);
-            general_grid.attach (settings_switch, 1, 5, 1, 1);
+            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_SHADOW), 0, 5 + top_offset, 1, 1);
+            general_grid.attach (settings_switch, 1, 5 + top_offset, 1, 1);
             settings_switch.set_active (this.manager.get_settings ().textshadow);
             settings_switch.notify["active"].connect (this.window.on_toggle_shadow);
             // text bold
             settings_switch = new SettingsSwitch ("text_bold");
-            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_BOLD), 0, 6, 1, 1);
-            general_grid.attach (settings_switch, 1, 6, 1, 1);
+            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.DESKTOPFOLDER_MENU_TEXT_BOLD), 0, 6 + top_offset, 1, 1);
+            general_grid.attach (settings_switch, 1, 6 + top_offset, 1, 1);
             settings_switch.set_active (this.manager.get_settings ().textbold);
             settings_switch.notify["active"].connect (this.window.on_toggle_bold);
 

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -108,7 +108,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
             this.settings.save ();
             this.arrangement               = FolderArrangement.factory (this.settings.arrangement_type);
 
-            if (this.arrangement.forze_organization ()) {
+            if (this.arrangement.force_organization ()) {
                 this.organize_panel_items ();
             }
         }
@@ -248,6 +248,9 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
             } else {
                 // somehthing changed.. created or removed
                 this.sync_files (0, 0);
+                if (this.arrangement.force_organization ()) {
+                    this.organize_panel_items ();
+                }
             }
 
         }
@@ -357,7 +360,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
                     newItemsToPosition.append (file_name);
                 } else {
                     // lets check if the item already exists
-                    ItemManager oldItemManager = popItemFromList (file_name, ref oldItems);
+                    ItemManager oldItemManager = pop_item_from_list (file_name, ref oldItems);
                     if (oldItemManager != null) {
                         this.items.append (oldItemManager);
                     } else {
@@ -419,13 +422,13 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
     }
 
     /**
-     * @name popItemFromList
+     * @name pop_item_from_list
      * @description try to ind an item in a item list by the file get_name
      * @param string file_name the file name of the item
      * @param List<ItemManager> the list to search inside (reference)
      * @return ItemManager the itemmanager found, or null if none match
      */
-    private ItemManager ? popItemFromList (string file_name, ref List <ItemManager> items) {
+    private ItemManager ? pop_item_from_list (string file_name, ref List <ItemManager> items) {
         foreach (ItemManager item in items) {
             if (item.get_file_name () == file_name) {
                 items.remove (item);

--- a/src/logic/folderarrangement/FolderArrangement.vala
+++ b/src/logic/folderarrangement/FolderArrangement.vala
@@ -55,11 +55,11 @@ public interface DesktopFolder.FolderArrangement : Object {
     public abstract bool can_organize ();
 
     /**
-     * @name forze_organization
-     * @description indicates whether the arrangement must foze the organization when the panel is resized
-     * @return bool true->yes, forze, othwerise false
+     * @name force_organization
+     * @description indicates whether the arrangement must force the organization when the panel is resized
+     * @return bool true->yes, force, othwerise false
      */
-    public abstract bool forze_organization ();
+    public abstract bool force_organization ();
 
     /**
      * Factory method to obtain an arragement type

--- a/src/logic/folderarrangement/FolderArrangementFree.vala
+++ b/src/logic/folderarrangement/FolderArrangementFree.vala
@@ -38,7 +38,7 @@ public class DesktopFolder.FolderArrangementFree : Object, FolderArrangement {
         return true;
     }
 
-    public bool forze_organization () {
+    public bool force_organization () {
         return false;
     }
 

--- a/src/logic/folderarrangement/FolderArrangementGrid.vala
+++ b/src/logic/folderarrangement/FolderArrangementGrid.vala
@@ -42,7 +42,7 @@ public class DesktopFolder.FolderArrangementGrid : Object, FolderArrangement {
         return true;
     }
 
-    public bool forze_organization () {
+    public bool force_organization () {
         return false;
     }
 

--- a/src/logic/folderarrangement/FolderArrangementManaged.vala
+++ b/src/logic/folderarrangement/FolderArrangementManaged.vala
@@ -38,7 +38,7 @@ public class DesktopFolder.FolderArrangementManaged : Object, FolderArrangement 
         return false;
     }
 
-    public bool forze_organization () {
+    public bool force_organization () {
         return true;
     }
 

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -83,7 +83,7 @@ namespace DesktopFolder.Util {
         string src_path        = src.get_path ();
 
         GLib.File real_dest = dest;
-        if (src_path == dest_path) {
+        if (src_path == real_dest.get_path ()) {
             string basename = dest.get_basename ();
             string dirname  = dest.get_path ().replace (basename, "");
             real_dest = GLib.File.new_for_path (dirname + make_next_duplicate_name (basename, dirname));

--- a/src/utils/Util.vala
+++ b/src/utils/Util.vala
@@ -81,32 +81,32 @@ namespace DesktopFolder.Util {
         GLib.FileType src_type = src.query_file_type (GLib.FileQueryInfoFlags.NONE, cancellable);
 
         string src_path        = src.get_path ();
-        string dest_path       = dest.get_path ();
+
+        GLib.File real_dest = dest;
+        if (src_path == dest_path) {
+            string basename = dest.get_basename ();
+            string dirname  = dest.get_path ().replace (basename, "");
+            real_dest = GLib.File.new_for_path (dirname + make_next_duplicate_name (basename, dirname));
+        }
 
         if (src_type == GLib.FileType.DIRECTORY) {
-            dest.make_directory (cancellable);
-            src.copy_attributes (dest, flags, cancellable);
+            real_dest.make_directory (cancellable);
+            src.copy_attributes (real_dest, flags, cancellable);
 
             GLib.FileEnumerator enumerator = src.enumerate_children (GLib.FileAttribute.STANDARD_NAME, GLib.FileQueryInfoFlags.NONE, cancellable);
             for (GLib.FileInfo ? info = enumerator.next_file (cancellable); info != null; info = enumerator.next_file (cancellable)) {
                 copy_recursive (
                     GLib.File.new_for_path (GLib.Path.build_filename (src_path, info.get_name ())),
-                    GLib.File.new_for_path (GLib.Path.build_filename (dest_path, info.get_name ())),
+                    GLib.File.new_for_path (GLib.Path.build_filename (real_dest.get_path (), info.get_name ())),
                     flags,
                     cancellable, listener
                 );
             }
         } else if (src_type == GLib.FileType.REGULAR) {
             if (listener != null) {
-                listener (dest);
+                listener (real_dest);
             } else {
-                debug ("copying %s", dest.get_basename ());
-            }
-            GLib.File real_dest = dest;
-            if (src_path == dest_path) {
-                string basename = dest.get_basename ();
-                string dirname  = dest.get_path ().replace (basename, "");
-                real_dest = GLib.File.new_for_path (dirname + make_next_duplicate_name (basename, dirname));
+                debug ("copying %s", real_dest.get_basename ());
             }
 
             src.copy (real_dest, flags, cancellable);
@@ -247,6 +247,19 @@ namespace DesktopFolder.Util {
             ext         = name.substring (ext_pos);
             name_no_ext = name.replace (ext, "");
             name_no_ext = name_no_ext.strip ();
+        }
+        try {
+            var regex = new Regex ("([ ]+[0-9]+)$");
+            MatchInfo matchinfo;
+            if (regex.match(name_no_ext, 0, out matchinfo)) {
+                int startpos = 0;
+                int endpos = 0;
+                matchinfo.fetch_pos (0, out startpos, out endpos);
+                string regex_output = name_no_ext.slice ((long) startpos, (long) endpos);
+                name_no_ext = name_no_ext.splice ((long) startpos, (long) endpos);
+            }
+        } catch (Error e) {
+            debug (@"Error: $(e.message)");
         }
 
         string new_filename = "";

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -189,10 +189,10 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         new_submenu.append (newlinkpanel_item);
         new_submenu.append (newnote_item);
         new_submenu.append (newphoto_item);
+        context_menu.append (new MenuItemSeparator ());
 
         if (this.manager.get_application ().get_desktopicons_enabled ()) {
             // sortby submenu ---------
-            context_menu.append (new MenuItemSeparator ());
             context_menu.append (sortby_item);
             sortby_item.set_submenu (sortby_submenu);
             sortby_submenu.append (sortby_name_item);
@@ -203,11 +203,15 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
             if (this.manager.get_arrangement ().can_organize ()) {
                 context_menu.append (organize_item);
             }
-            // -------------------------
             context_menu.append (new MenuItemSeparator ());
-            context_menu.append (textcolor_item);
         }
         context_menu.append (properties_item);
+        context_menu.append (new MenuItemSeparator ());
+
+        if (this.manager.get_application ().get_desktopicons_enabled ()) {
+            context_menu.append (textcolor_item);
+            context_menu.append (new MenuItemSeparator ());
+        }
         context_menu.append (desktop_item);
         if (this.manager.get_application ().get_desktopicons_enabled ()) {
             context_menu.append (new MenuItemSeparator ());

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -173,6 +173,7 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
                 var paste_item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_PASTE);
                 paste_item.activate.connect (this.manager.paste);
                 context_menu.append (paste_item);
+                context_menu.append (new MenuItemSeparator ());
             }
         }
         context_menu.append (new_item);

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -428,7 +428,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
             // debug ("set_new_shape: %i,%i,%i,%i", x, y, w, h);
             this.manager.set_new_shape (x, y, w, h);
 
-            if (this.manager.get_arrangement ().forze_organization ()) {
+            if (this.manager.get_arrangement ().force_organization ()) {
                 this.manager.organize_panel_items ();
             }
         }

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -673,7 +673,7 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         item.show ();
         menu.append (item);
 
-        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_DELETE);
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_TRASH);
         item.activate.connect ((item) => { this.manager.trash (); });
         item.show ();
         menu.append (item);

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -557,8 +557,9 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         var  mods            = event.state & Gtk.accelerator_get_default_mod_mask ();
         bool control_pressed = ((mods & Gdk.ModifierType.CONTROL_MASK) != 0);
         bool can_drag        = this.manager.get_folder ().get_arrangement ().can_drag ();
+        bool locked       = this.manager.get_folder ().are_items_locked ();
 
-        if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_PRIMARY && (control_pressed || !can_drag)) {
+        if (event.type == Gdk.EventType.BUTTON_PRESS && event.button == Gdk.BUTTON_PRIMARY && (control_pressed || !can_drag || !locked)) {
             this.select ();
             this.flag_dragdrop_started = true;
             return false;


### PR DESCRIPTION
- Reorganise desktop context menu a bit
- Fix doubling of "When changing resolution" label
- Change label text slightly
- Remove hint for "default icon arrangement" because I think the label is enough to understand what it does
- Don't show "lock panel" for the desktop panel in panel properties because it does nothing
- Drag and drop when items are locked
- Copying a folder into the same parent folder now duplicates like files
- Don't create a link if the target file/folder already exists (if the target was a folder it was creating a link in there)
- Fix icon context menu trash label saying "Delete"
- Fix #192 