### PR TITLE
Show/hide desktop

### DIFF
--- a/data/com.github.spheras.desktopfolder.gschema.xml
+++ b/data/com.github.spheras.desktopfolder.gschema.xml
@@ -24,11 +24,6 @@
       <summary>Desktop Panel over Desktop</summary>
       <description>Desktop Transparent Panel to allow desktop interaction</description>
     </key>
-    <key name="first-time-hiding-desktop" type="b">
-      <default>true</default>
-      <summary>First Time Hiding Desktop</summary>
-      <description>If the user hasn't tried to hide the desktop by double clicking it yet</description>
-    </key>
     <key name="resolution-strategy" enum="resolution-strategy">
       <default>'STORE'</default>
       <summary>Resolution Change Strategy</summary>

--- a/data/com.github.spheras.desktopfolder.gschema.xml
+++ b/data/com.github.spheras.desktopfolder.gschema.xml
@@ -24,6 +24,11 @@
       <summary>Desktop Panel over Desktop</summary>
       <description>Desktop Transparent Panel to allow desktop interaction</description>
     </key>
+    <key name="first-time-hiding-desktop" type="b">
+      <default>true</default>
+      <summary>First Time Hiding Desktop</summary>
+      <description>If the user hasn't tried to hide the desktop by double clicking it yet</description>
+    </key>
     <key name="resolution-strategy" enum="resolution-strategy">
       <default>'STORE'</default>
       <summary>Resolution Change Strategy</summary>

--- a/data/css/Application.css
+++ b/data/css/Application.css
@@ -45,6 +45,42 @@
     color: @colorForegroundHEADLESS;
 }
 
+@keyframes fade {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+/* Windows opacity animation */
+.df_fadingwindow {
+    /*animation-duration: 1s;*/
+    /*animation-name: fade;*/
+    /*animation-iteration-count: infinite;*/
+    /*animation-direction: alternate;*/
+    /*animation-timing-function: cubic-bezier(0.455, 0.030, 0.515, 0.955);*/
+    transition: opacity 160ms cubic-bezier(0.455, 0.030, 0.515, 0.955);
+}
+
+.df_fadein {
+    opacity: 1;
+}
+
+.df_fadeout {
+    opacity: 0;
+}
+
+/* Panel buttons (trash and properties) */
+.df_folder .df_titlebar_button {
+    opacity: 0.75;
+    -gtk-icon-shadow: none;
+
+    transition: opacity 100ms cubic-bezier(0.455, 0.030, 0.515, 0.955);
+}
+
 /* Panel buttons (trash and properties) */
 .df_folder .df_titlebar_button {
     opacity: 0.75;

--- a/data/css/Application.css
+++ b/data/css/Application.css
@@ -45,23 +45,8 @@
     color: @colorForegroundHEADLESS;
 }
 
-@keyframes fade {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
-
 /* Windows opacity animation */
 .df_fadingwindow {
-    /*animation-duration: 1s;*/
-    /*animation-name: fade;*/
-    /*animation-iteration-count: infinite;*/
-    /*animation-direction: alternate;*/
-    /*animation-timing-function: cubic-bezier(0.455, 0.030, 0.515, 0.955);*/
     transition: opacity 160ms cubic-bezier(0.455, 0.030, 0.515, 0.955);
 }
 
@@ -71,14 +56,6 @@
 
 .df_fadeout {
     opacity: 0;
-}
-
-/* Panel buttons (trash and properties) */
-.df_folder .df_titlebar_button {
-    opacity: 0.75;
-    -gtk-icon-shadow: none;
-
-    transition: opacity 100ms cubic-bezier(0.455, 0.030, 0.515, 0.955);
 }
 
 /* Panel buttons (trash and properties) */

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -37,6 +37,9 @@ public class DesktopFolderApp : Gtk.Application {
     private bool show_desktoppanel              = false;
     private bool show_desktopicons              = false;
 
+    private bool desktop_visible                = true;
+    private bool first_hide                     = false;
+
     /** List of folder owned by the application */
     private DesktopFolder.DesktopManager desktop       = null;
     private List <DesktopFolder.FolderManager> folders = new List <DesktopFolder.FolderManager> ();
@@ -132,6 +135,8 @@ public class DesktopFolderApp : Gtk.Application {
         } catch (Error error) {
             // we don't have any files settings, using default config
         }
+
+        first_hide = settings.get_boolean ("first-time-hiding-desktop");
 
         // Connect to show-desktopfolder key
         settings.changed[SHOW_DESKTOPFOLDER_KEY].connect (on_show_desktopfolder_changed);
@@ -596,13 +601,43 @@ public class DesktopFolderApp : Gtk.Application {
     }
 
     /**
+     * @name get_desktop_visibility
+     * @description show or hide the desktop
+     */
+    public bool get_desktop_visibility () {
+        return this.desktop_visible;
+    }
+
+    /**
+     * @name toggle_desktop_visiblity
+     * @description show or hide the desktop
+     */
+    public void toggle_desktop_visibility () {
+        this.desktop_visible = !this.desktop_visible;
+        if (!this.desktop_visible && first_hide) {
+            //var notification = new Notification ("Desktop hidden");
+            //notification.set_body ("Double click on the desktop to show it again");
+            //send_notification(null, notification);
+        }
+        this.desktop.show_view (this.desktop_visible);
+        foreach (var folder in folders) {
+            folder.show_view (this.desktop_visible);
+        }
+        foreach (var note in notes) {
+            note.show_view (this.desktop_visible);
+        }
+        foreach (var photo in photos) {
+            photo.show_view (this.desktop_visible);
+        }
+    }
+
+    /**
      * @name clear_folders
      * @description close all the folders launched
      */
     protected void clear_folders () {
-        for (int i = 0; i < this.folders.length (); i++) {
-            var fm = this.folders.nth (i).data;
-            fm.close ();
+        foreach (var folder in folders) {
+            folder.close ();
         }
         this.folders = new List <DesktopFolder.FolderManager> ();
     }
@@ -612,9 +647,8 @@ public class DesktopFolderApp : Gtk.Application {
      * @description close all the notes launched
      */
     protected void clear_notes () {
-        for (int i = 0; i < this.notes.length (); i++) {
-            var fm = this.notes.nth (i).data;
-            fm.close ();
+        foreach (var note in notes) {
+            note.close ();
         }
         this.notes = new List <DesktopFolder.NoteManager> ();
     }
@@ -624,9 +658,8 @@ public class DesktopFolderApp : Gtk.Application {
      * @description close all the photos launched
      */
     protected void clear_photos () {
-        for (int i = 0; i < this.photos.length (); i++) {
-            var fm = this.photos.nth (i).data;
-            fm.close ();
+        foreach (var photo in photos) {
+            photo.close ();
         }
         this.photos = new List <DesktopFolder.PhotoManager> ();
     }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -37,7 +37,7 @@ public class DesktopFolderApp : Gtk.Application {
     private bool show_desktoppanel              = false;
     private bool show_desktopicons              = false;
 
-    private bool desktop_visible                = true;
+    private bool desktop_visible                = false;
     private bool first_hide                     = false;
 
     /** List of folder owned by the application */
@@ -201,6 +201,11 @@ public class DesktopFolderApp : Gtk.Application {
         this.volume_monitor.volume_changed.connect ((volume) => {
             this.on_mount_changed ();
         });
+
+        Timeout.add (1000, () => {
+            this.toggle_desktop_visibility ();
+            return false;
+        });
     }
 
     /**
@@ -289,14 +294,14 @@ public class DesktopFolderApp : Gtk.Application {
         if (this.desktop != null) {
             this.desktop.on_screen_size_changed (screen);
         }
-        for (int i = 0; i < this.folders.length (); i++) {
-            this.folders.nth_data (i).on_screen_size_changed (screen);
+        foreach (var folder in folders) {
+            folder.on_screen_size_changed (screen);
         }
-        for (int i = 0; i < this.notes.length (); i++) {
-            this.notes.nth_data (i).on_screen_size_changed (screen);
+        foreach (var note in notes) {
+            note.on_screen_size_changed (screen);
         }
-        for (int i = 0; i < this.photos.length (); i++) {
-            this.photos.nth_data (i).on_screen_size_changed (screen);
+        foreach (var photo in photos) {
+            photo.on_screen_size_changed (screen);
         }
     }
 
@@ -614,20 +619,34 @@ public class DesktopFolderApp : Gtk.Application {
      */
     public void toggle_desktop_visibility () {
         this.desktop_visible = !this.desktop_visible;
+        debug (@"desktop_visible is now $(this.desktop_visible)");
         if (!this.desktop_visible && first_hide) {
             //var notification = new Notification ("Desktop hidden");
             //notification.set_body ("Double click on the desktop to show it again");
             //send_notification(null, notification);
         }
-        this.desktop.show_view (this.desktop_visible);
-        foreach (var folder in folders) {
-            folder.show_view (this.desktop_visible);
-        }
-        foreach (var note in notes) {
-            note.show_view (this.desktop_visible);
-        }
-        foreach (var photo in photos) {
-            photo.show_view (this.desktop_visible);
+        if (this.desktop_visible) {
+            this.desktop.show_view ();
+            foreach (var folder in folders) {
+                folder.show_view ();
+            }
+            foreach (var note in notes) {
+                note.show_view ();
+            }
+            foreach (var photo in photos) {
+                photo.show_view ();
+            }
+        } else {
+            this.desktop.hide_view ();
+            foreach (var folder in folders) {
+                folder.hide_view ();
+            }
+            foreach (var note in notes) {
+                note.hide_view ();
+            }
+            foreach (var photo in photos) {
+                photo.hide_view ();
+            }
         }
     }
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -202,7 +202,7 @@ public class DesktopFolderApp : Gtk.Application {
             this.on_mount_changed ();
         });
 
-        Timeout.add (1000, () => {
+        Timeout.add (500, () => {// 1000
             this.toggle_desktop_visibility ();
             return false;
         });

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -38,7 +38,6 @@ public class DesktopFolderApp : Gtk.Application {
     private bool show_desktopicons              = false;
 
     private bool desktop_visible                = false;
-    private bool first_hide                     = false;
 
     /** List of folder owned by the application */
     private DesktopFolder.DesktopManager desktop       = null;
@@ -135,8 +134,6 @@ public class DesktopFolderApp : Gtk.Application {
         } catch (Error error) {
             // we don't have any files settings, using default config
         }
-
-        first_hide = settings.get_boolean ("first-time-hiding-desktop");
 
         // Connect to show-desktopfolder key
         settings.changed[SHOW_DESKTOPFOLDER_KEY].connect (on_show_desktopfolder_changed);
@@ -620,11 +617,6 @@ public class DesktopFolderApp : Gtk.Application {
     public void toggle_desktop_visibility () {
         this.desktop_visible = !this.desktop_visible;
         debug (@"desktop_visible is now $(this.desktop_visible)");
-        if (!this.desktop_visible && first_hide) {
-            //var notification = new Notification ("Desktop hidden");
-            //notification.set_body ("Double click on the desktop to show it again");
-            //send_notification(null, notification);
-        }
         if (this.desktop_visible) {
             this.desktop.show_view ();
             foreach (var folder in folders) {

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -221,4 +221,7 @@ namespace DesktopFolder.Lang {
     // the title of a note when a new one is created
     public const string NEWLY_CREATED_NOTE               = _("New Note");
 
+    public const string DESKTOPFOLDER_MENU_SHOW_DESKTOP  = _("Show Desktop");
+    public const string DESKTOPFOLDER_MENU_HIDE_DESKTOP  = _("Hide Desktop");
+
 }

--- a/src/logic/DesktopManager.vala
+++ b/src/logic/DesktopManager.vala
@@ -80,18 +80,20 @@ public class DesktopFolder.DesktopManager : DesktopFolder.FolderManager {
 
     /**
      * @name show_view
-     * @description show or hide the view
-     * @param bool whether to show the view or not
+     * @description show the items on the desktop
+     * @override
      */
-    public override void show_view (bool show) {
-        debug (@"show_view $show");
-        if (show) {
-            debug ("showing");
-            this.show_items ();
-        } else {
-            debug ("hiding");
-            this.hide_items ();
-        }
+    public override void show_view () {
+        this.show_items ();
+    }
+
+    /**
+     * @name hide_view
+     * @description hide the items on the desktop
+     * @override
+     */
+    public override void hide_view () {
+        this.hide_items ();
     }
 
 

--- a/src/logic/DesktopManager.vala
+++ b/src/logic/DesktopManager.vala
@@ -56,6 +56,47 @@ public class DesktopFolder.DesktopManager : DesktopFolder.FolderManager {
     }
 
     /**
+     * @name show_items
+     * @description shows the items
+     */
+    public override void show_items () {
+        debug (@"show_items $(this.get_application ().get_desktop_visibility ())");
+        if (this.get_application ().get_desktop_visibility ()) {
+            debug ("showing items");
+            base.show_items ();
+            base.view.refresh ();
+        }
+    }
+
+    /**
+     * @name hide_items
+     * @description hides the items
+     */
+    public override void hide_items () {
+        debug (@"hide_items $(this.get_application ().get_desktop_visibility ())");
+        debug ("hiding items");
+        base.hide_items ();
+    }
+
+    /**
+     * @name show_view
+     * @description show or hide the view
+     * @param bool whether to show the view or not
+     */
+    public override void show_view (bool show) {
+        debug (@"show_view $show");
+        if (show) {
+            debug ("showing");
+            this.show_items ();
+        } else {
+            debug ("hiding");
+            this.hide_items ();
+        }
+    }
+
+
+
+    /**
      * @name on_screen_size_changed
      * @description detecting screen size changes
      */

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -45,6 +45,8 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
     private FolderArrangement arrangement        = null;
     // the last selected item
     private ItemView selected_item               = null;
+    private int previous_x                       = 0;
+    private int previous_y                       = 0;
 
 
     /**
@@ -75,7 +77,6 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
         this.monitor_folder ();
 
         this.dnd_behaviour = new DragnDrop.DndBehaviour (this, false, true);
-        this.view.show_all ();
     }
 
     /**
@@ -457,15 +458,28 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
 
     /**
      * @name show_view
-     * @description show or hide the view
-     * @param bool whether to show the view or not
+     * @description show the folder
      */
-    public virtual void show_view (bool show) {
-        if (show) {
-            this.view.show_all ();
-        } else {
+    public virtual void show_view () {
+        // setting opacity to stop the folder window flashing at startup
+        this.view.opacity = 1;
+        this.view.show_all ();
+        this.view.fade_in ();
+        this.show_items ();
+    }
+
+    /**
+     * @name hide_view
+     * @description hide the folder
+     */
+    public virtual void hide_view () {
+        this.view.fade_out ();
+        Timeout.add (160, () => {
+            // ditto
+            this.view.opacity = 0;
             this.view.hide ();
-        }
+            return false;
+        });
     }
 
     /**

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -437,6 +437,24 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
     }
 
     /**
+     * @name quick_show_items
+     * @description shows the items
+     */
+    public void quick_show_items () {
+        // TODO Make this less messy
+        foreach (var item in items) {
+            item.get_view ().show_all ();
+            item.get_view ().get_style_context ().remove_class ("df_fadingwindow");
+            item.get_view ().get_style_context ().remove_class ("df_fadeout");
+            item.get_view ().get_style_context ().add_class ("df_fadein");
+            Timeout.add (20, () => {
+                item.get_view ().get_style_context ().add_class ("df_fadingwindow");
+                return false;
+            });
+        }
+    }
+
+    /**
      * @name show_items
      * @description shows the items
      */

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -45,8 +45,6 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
     private FolderArrangement arrangement        = null;
     // the last selected item
     private ItemView selected_item               = null;
-    private int previous_x                       = 0;
-    private int previous_y                       = 0;
 
 
     /**

--- a/src/logic/FolderManager.vala
+++ b/src/logic/FolderManager.vala
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public errordomain FolderManagerIOError {
+protected errordomain FolderManagerIOError {
     FILE_EXISTS,
     MOVE_ERROR
 }
@@ -426,7 +426,7 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @return ItemManager the itemmanager found, or null if none match
      */
     private ItemManager ? popItemFromList (string file_name, ref List <ItemManager> items) {
-        foreach (ItemManager item in items) {
+        foreach (var item in items) {
             if (item.get_file_name () == file_name) {
                 items.remove (item);
                 return item;
@@ -439,8 +439,8 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @name show_items
      * @description shows the items
      */
-    public void show_items () {
-        foreach (ItemManager item in items) {
+    public virtual void show_items () {
+        foreach (var item in items) {
             item.show_view ();
         }
     }
@@ -449,9 +449,22 @@ public class DesktopFolder.FolderManager : Object, DragnDrop.DndView {
      * @name hide_items
      * @description hides the items
      */
-    public void hide_items () {
-        foreach (ItemManager item in items) {
+    public virtual void hide_items () {
+        foreach (var item in items) {
             item.hide_view ();
+        }
+    }
+
+    /**
+     * @name show_view
+     * @description show or hide the view
+     * @param bool whether to show the view or not
+     */
+    public virtual void show_view (bool show) {
+        if (show) {
+            this.view.show_all ();
+        } else {
+            this.view.hide ();
         }
     }
 

--- a/src/logic/ItemManager.vala
+++ b/src/logic/ItemManager.vala
@@ -122,15 +122,19 @@ public class DesktopFolder.ItemManager : Object, DragnDrop.DndView, Clipboard.Cl
      * @description show the icon
      */
     public void show_view () {
-        this.view.show ();
+        this.view.show_all ();
+        this.view.fade_in ();
     }
-
     /**
      * @name hide_view
      * @description hide the icon
      */
     public void hide_view () {
-        this.view.hide ();
+        this.view.fade_out ();
+        Timeout.add (160, () => {
+            this.view.hide ();
+            return false;
+        });
     }
 
     /**

--- a/src/logic/NoteManager.vala
+++ b/src/logic/NoteManager.vala
@@ -72,7 +72,7 @@ public class DesktopFolder.NoteManager : Object {
      * @name on_screen_size_changed
      * @description detecting screen size changes
      */
-    public virtual void on_screen_size_changed (Gdk.Screen screen) {
+    public void on_screen_size_changed (Gdk.Screen screen) {
         this.settings.calculate_current_position ();
         this.view.reload_settings ();
     }
@@ -178,7 +178,7 @@ public class DesktopFolder.NoteManager : Object {
      * @name show_view
      * @description show the folder
      */
-    public virtual void show_view () {
+    public void show_view () {
         // setting opacity to stop the folder window flashing at startup
         this.view.opacity = 1;
         this.view.show_all ();
@@ -189,7 +189,7 @@ public class DesktopFolder.NoteManager : Object {
      * @name hide_view
      * @description hide the folder
      */
-    public virtual void hide_view () {
+    public void hide_view () {
         this.view.fade_out ();
         Timeout.add (160, () => {
             // ditto

--- a/src/logic/NoteManager.vala
+++ b/src/logic/NoteManager.vala
@@ -175,6 +175,19 @@ public class DesktopFolder.NoteManager : Object {
     }
 
     /**
+     * @name show_view
+     * @description show or hide the view
+     * @param bool whether to show the view or not
+     */
+    public void show_view (bool show) {
+        if (show) {
+            this.view.show_all ();
+        } else {
+            this.view.hide ();
+        }
+    }
+
+    /**
      * @name get_file
      * @description return the Glib.File associated
      * @return File the file associated

--- a/src/logic/NoteManager.vala
+++ b/src/logic/NoteManager.vala
@@ -176,15 +176,27 @@ public class DesktopFolder.NoteManager : Object {
 
     /**
      * @name show_view
-     * @description show or hide the view
-     * @param bool whether to show the view or not
+     * @description show the folder
      */
-    public void show_view (bool show) {
-        if (show) {
-            this.view.show_all ();
-        } else {
+    public virtual void show_view () {
+        // setting opacity to stop the folder window flashing at startup
+        this.view.opacity = 1;
+        this.view.show_all ();
+        this.view.fade_in ();
+    }
+
+    /**
+     * @name hide_view
+     * @description hide the folder
+     */
+    public virtual void hide_view () {
+        this.view.fade_out ();
+        Timeout.add (160, () => {
+            // ditto
+            this.view.opacity = 0;
             this.view.hide ();
-        }
+            return false;
+        });
     }
 
     /**

--- a/src/logic/PhotoManager.vala
+++ b/src/logic/PhotoManager.vala
@@ -151,15 +151,27 @@ public class DesktopFolder.PhotoManager : Object {
 
     /**
      * @name show_view
-     * @description show or hide the view
-     * @param bool whether to show the view or not
+     * @description show the folder
      */
-    public void show_view (bool show) {
-        if (show) {
-            this.view.show_all ();
-        } else {
+    public virtual void show_view () {
+        // setting opacity to stop the folder window flashing at startup
+        this.view.opacity = 1;
+        this.view.show_all ();
+        this.view.fade_in ();
+    }
+
+    /**
+     * @name hide_view
+     * @description hide the folder
+     */
+    public virtual void hide_view () {
+        this.view.fade_out ();
+        Timeout.add (160, () => {
+            // ditto
+            this.view.opacity = 0;
             this.view.hide ();
-        }
+            return false;
+        });
     }
 
     /**

--- a/src/logic/PhotoManager.vala
+++ b/src/logic/PhotoManager.vala
@@ -74,7 +74,7 @@ public class DesktopFolder.PhotoManager : Object {
      * @name on_screen_size_changed
      * @description detecting screen size changes
      */
-    public virtual void on_screen_size_changed (Gdk.Screen screen) {
+    public void on_screen_size_changed (Gdk.Screen screen) {
         this.settings.calculate_current_position ();
         this.view.reload_settings ();
     }
@@ -153,7 +153,7 @@ public class DesktopFolder.PhotoManager : Object {
      * @name show_view
      * @description show the folder
      */
-    public virtual void show_view () {
+    public void show_view () {
         // setting opacity to stop the folder window flashing at startup
         this.view.opacity = 1;
         this.view.show_all ();
@@ -164,7 +164,7 @@ public class DesktopFolder.PhotoManager : Object {
      * @name hide_view
      * @description hide the folder
      */
-    public virtual void hide_view () {
+    public void hide_view () {
         this.view.fade_out ();
         Timeout.add (160, () => {
             // ditto

--- a/src/logic/PhotoManager.vala
+++ b/src/logic/PhotoManager.vala
@@ -150,6 +150,19 @@ public class DesktopFolder.PhotoManager : Object {
     }
 
     /**
+     * @name show_view
+     * @description show or hide the view
+     * @param bool whether to show the view or not
+     */
+    public void show_view (bool show) {
+        if (show) {
+            this.view.show_all ();
+        } else {
+            this.view.hide ();
+        }
+    }
+
+    /**
      * @name get_file
      * @description return the Glib.File associated
      * @return File the file associated

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -38,6 +38,15 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         return true;
     }
 
+    protected override bool on_press (Gdk.EventButton event) {
+        if (event.type == Gdk.EventType.@2BUTTON_PRESS) {
+            debug ("toggling desktop visiblity");
+            base.get_manager ().get_application ().toggle_desktop_visibility ();
+        }
+        base.on_press (event);
+        return true;
+    }
+
     /**
      * @name move_to
      * @description move the window to other position
@@ -67,8 +76,11 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
      * @overrided
      */
     public override void refresh () {
-        this.show_all ();
-        if (!this.manager.get_application ().get_desktopicons_enabled ()) {
+        var app = this.manager.get_application ();
+        if (app.get_desktop_visibility () && app.get_desktopicons_enabled ()) {
+            debug ("refresh, icons enabled and desktop visibility = true");
+            this.show_all ();
+        } else {
             debug ("trying to hide");
             this.manager.hide_items ();
         }
@@ -91,6 +103,8 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         // Forcing desktop mode to avoid minimization in certain extreme cases without on_press signal!
         // TODO: Is there a way to make a desktop window resizable and movable?
 
+        bool show_icon_options = this.manager.get_application ().get_desktoppanel_enabled () && this.manager.get_application ().get_desktopicons_enabled () && this.manager.get_application ().get_desktop_visibility ();
+
         this.type_hint    = Gdk.WindowTypeHint.DESKTOP;
         this.context_menu = new Gtk.Menu ();
         Clipboard.ClipboardManager cm = Clipboard.ClipboardManager.get_for_display ();
@@ -109,6 +123,12 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         var newphoto_item     = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_NEW_PHOTO);
         var properties_item   = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_PROPERTIES_TOOLTIP);
         var desktop_item      = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_CHANGEDESKTOP);
+        Gtk.MenuItem show_desktop_item;
+        if (this.manager.get_application ().get_desktop_visibility ()) {
+            show_desktop_item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_HIDE_DESKTOP);
+        } else {
+            show_desktop_item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_SHOW_DESKTOP);
+        }
         var openterminal_item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_OPENTERMINAL);
 
         // sortby submenu -----------
@@ -124,7 +144,7 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         var textcolor_item = new MenuItemColor (HEAD_TAGS_COLORS, this, null);
 
         // Events (please try and keep these in the same order as appended to the menu)
-        if (this.manager.get_application ().get_desktopicons_enabled ()) {
+        if (show_icon_options) {
             newfolder_item.activate.connect (() => { this.new_folder ((int) event.x, (int) event.y); });
             emptyfile_item.activate.connect (() => { this.new_text_file ((int) event.x, (int) event.y); });
             newlink_item.activate.connect (() => { this.new_link ((int) event.x, (int) event.y, false); });
@@ -134,7 +154,7 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         newlinkpanel_item.activate.connect (() => { this.new_link_panel ((int) event.x, (int) event.y); });
         newnote_item.activate.connect (() => { this.new_note ((int) event.x, (int) event.y); });
         newphoto_item.activate.connect (() => { this.new_photo ((int) event.x, (int) event.y); });
-        if (this.manager.get_application ().get_desktopicons_enabled ()) {
+        if (show_icon_options) {
             // sortby submenu ---------
             sortby_name_item.set_active (this.manager.get_settings ().sort_by_type == FolderSort.SORT_BY_NAME);
             sortby_size_item.set_active (this.manager.get_settings ().sort_by_type == FolderSort.SORT_BY_SIZE);
@@ -165,7 +185,9 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         ((Gtk.MenuItem)properties_item).activate.connect (this.show_properties_dialog);
         ((Gtk.MenuItem)desktop_item).activate.connect (this.show_desktop_dialog);
 
-        if (this.manager.get_application ().get_desktopicons_enabled ()) {
+        ((Gtk.MenuItem)show_desktop_item).activate.connect (this.manager.get_application ().toggle_desktop_visibility);
+
+        if (show_icon_options) {
             openterminal_item.activate.connect (this.open_terminal);
 
             // Appending (in order)
@@ -177,7 +199,7 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         }
         context_menu.append (new_item);
         new_item.set_submenu (new_submenu);
-        if (this.manager.get_application ().get_desktopicons_enabled ()) {
+        if (show_icon_options) {
             new_submenu.append (newfolder_item);
             new_submenu.append (emptyfile_item);
             new_submenu.append (new MenuItemSeparator ());
@@ -190,7 +212,7 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         new_submenu.append (newnote_item);
         new_submenu.append (newphoto_item);
 
-        if (this.manager.get_application ().get_desktopicons_enabled ()) {
+        if (show_icon_options) {
             // sortby submenu ---------
             context_menu.append (new MenuItemSeparator ());
             context_menu.append (sortby_item);
@@ -204,12 +226,16 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
                 context_menu.append (organize_item);
             }
             // -------------------------
+        }
+        context_menu.append (new MenuItemSeparator ());
+        context_menu.append (desktop_item);
+        context_menu.append (new MenuItemSeparator ());
+        context_menu.append (show_desktop_item);
+        context_menu.append (new MenuItemSeparator ());
+        context_menu.append (properties_item);
+        if (show_icon_options) {
             context_menu.append (new MenuItemSeparator ());
             context_menu.append (textcolor_item);
-        }
-        context_menu.append (properties_item);
-        context_menu.append (desktop_item);
-        if (this.manager.get_application ().get_desktopicons_enabled ()) {
             context_menu.append (new MenuItemSeparator ());
             context_menu.append (openterminal_item);
         }

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -75,6 +75,16 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
     /**
      * @overrided
      */
+    public override void reload_settings () {
+        base.reload_settings ();
+        this.get_style_context ().remove_class ("df_fadeout");
+        this.get_style_context ().add_class ("df_fadein");
+        this.opacity = 1;
+    }
+
+    /**
+     * @overrided
+     */
     public override void refresh () {
         var app = this.manager.get_application ();
         if (app.get_desktop_visibility () && app.get_desktopicons_enabled ()) {

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -430,6 +430,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
     public virtual void refresh () {
         if (this.manager.get_application ().get_desktop_visibility ()) {
             this.show_all ();
+            this.manager.quick_show_items ();
         }
     }
 

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -398,7 +398,9 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      * @description refresh the window
      */
     public virtual void refresh () {
-        this.show_all ();
+        if (this.manager.get_application ().get_desktop_visibility ()) {
+            this.show_all ();
+        }
     }
 
     /**
@@ -477,7 +479,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      * @description press event captured. The Window should show the popup on right button
      * @return bool @see widget on_press signal
      */
-    private bool on_press (Gdk.EventButton event) {
+    protected virtual bool on_press (Gdk.EventButton event) {
         // debug("on_press folderwindow");
         // Needed to exit focus from title when editting
         this.activate_focus ();

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -101,6 +101,8 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         }
 
         this.name                      = manager.get_application ().get_next_id ();
+        this.get_style_context ().add_class ("df_fadeout");
+
         this.trash_button              = new Gtk.Button.from_icon_name ("edit-delete-symbolic");
         this.trash_button.has_tooltip  = true;
         this.trash_button.tooltip_text = DesktopFolder.Lang.DESKTOPFOLDER_DELETE_TOOLTIP;
@@ -238,6 +240,24 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
     }
 
     /**
+     * @name fade_in
+     * @description fade the view in. does not call show
+     */
+    public void fade_in () {
+        this.get_style_context ().remove_class ("df_fadeout");
+        this.get_style_context ().add_class ("df_fadein");
+    }
+
+    /**
+     * @name fade_out
+     * @description fade the view out. does not call hide
+     */
+    public void fade_out () {
+        this.get_style_context ().remove_class ("df_fadein");
+        this.get_style_context ().add_class ("df_fadeout");
+    }
+
+    /**
      * @name move_to
      * @description move the window to other position
      */
@@ -260,7 +280,7 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
      * @name reload_settings
      * @description reload the window style in general
      */
-    public void reload_settings () {
+    public virtual void reload_settings () {
         FolderSettings settings = this.manager.get_settings ();
         if (settings.w > 0) {
             // applying existing position and size configuration
@@ -269,14 +289,24 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
             // debug ("Moving '%s' to (%d,%d), Resizing to (%d,%d)", this.manager.get_folder_name (), settings.x, settings.y, settings.w, settings.h);
         }
         List <unowned string> classes = this.get_style_context ().list_classes ();
-        for (int i = 0; i < classes.length (); i++) {
-            string class = classes.nth_data (i);
+        foreach (string class in classes) {
             if (class.has_prefix ("df_")) {
                 this.get_style_context ().remove_class (class);
             }
         }
         // we set a class to this window to manage the css
         this.get_style_context ().add_class ("df_folder");
+
+        this.get_style_context ().add_class ("df_fadingwindow");
+        if (this.manager.get_application ().get_desktop_visibility ()) {
+            this.get_style_context ().add_class ("df_fadein");
+            // setting opacity to stop the folder window flashing at startup
+            this.opacity = 1;
+        } else {
+            this.get_style_context ().add_class ("df_fadeout");
+            // ditto
+            this.opacity = 0;
+        }
 
         // applying existing colors configuration
         if (settings.bgcolor.has_prefix ("rgb")) {

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -140,7 +140,10 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         this.icon.set_size_request (ICON_WIDTH, ICON_WIDTH);
         this.icon.get_style_context ().add_class ("df_icon");
         this.container.pack_start (this.icon, true, true);
-        this.show_all ();
+        if (this.manager.get_folder ().get_application ().get_desktop_visibility ()) {
+            debug ("refresh_icon and desktop visibility = true");
+            this.show_all ();
+        }
     }
 
     /**

--- a/src/widgets/ItemView.vala
+++ b/src/widgets/ItemView.vala
@@ -82,6 +82,9 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         // class for this widget
         this.get_style_context ().add_class ("df_item");
 
+        this.get_style_context ().add_class ("df_fadingwindow");
+        this.get_style_context ().add_class ("df_fadeout");
+
         // we connect the enter and leave events
         this.enter_notify_event.connect (this.on_enter);
         this.leave_notify_event.connect (this.on_leave);
@@ -94,16 +97,12 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
         this.container.margin = 0;
         this.container.set_size_request (DEFAULT_WIDTH, DEFAULT_HEIGHT);
 
-        try {
-            this.refresh_icon ();
-            string slabel = this.get_correct_label (this.manager.get_file_name ());
-            this.create_label (slabel);
-        } catch (Error e) {
-            stderr.printf ("Error: %s\n", e.message);
-            Util.show_error_dialog ("Error", e.message);
-        }
+        this.refresh_icon ();
+        string slabel = this.get_correct_label (this.manager.get_file_name ());
+        this.create_label (slabel);
 
         this.add (this.container);
+
     }
 
     /**
@@ -111,18 +110,33 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
      * @description create the header bar
      */
     protected virtual void create_label (string slabel) {
-        // debug ("Create label for %s", this.manager.get_file_name ());
+        try {
+            // debug ("Create label for %s", this.manager.get_file_name ());
 
-        this.label = new DesktopFolder.EditableLabel (slabel);
-        this.container.pack_end (label, true, true, 0);
-        this.check_ellipse ();
+            this.label = new DesktopFolder.EditableLabel (slabel);
+            this.container.pack_end (label, true, true, 0);
+            this.check_ellipse ();
 
-        label.changed.connect ((new_name) => {
-            if (this.manager.rename (new_name + this.hidden_extension)) {
-                label.text = new_name;
-                this.check_ellipse ();
-            }
-        });
+            label.changed.connect ((new_name) => {
+                if (this.manager.rename (new_name + this.hidden_extension)) {
+                    label.text = new_name;
+                    this.check_ellipse ();
+                }
+            });
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            Util.show_error_dialog ("Error", e.message);
+        }
+    }
+
+    /**
+     * @name refresh
+     * @description refresh the window
+     */
+    public void refresh () {
+        if (this.manager.get_folder ().get_application ().get_desktop_visibility ()) {
+            this.show_all ();
+        }
     }
 
     /**
@@ -130,19 +144,21 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
      * @description force to refresh the icon imagen shown
      */
     public void refresh_icon () {
-        Gtk.Image newImage = this.calculate_icon ();
+        try {
+            Gtk.Image newImage = this.calculate_icon ();
 
-        if (this.icon != null) {
-            this.container.remove (this.icon);
-        }
+            if (this.icon != null) {
+                this.container.remove (this.icon);
+            }
 
-        this.icon = newImage;
-        this.icon.set_size_request (ICON_WIDTH, ICON_WIDTH);
-        this.icon.get_style_context ().add_class ("df_icon");
-        this.container.pack_start (this.icon, true, true);
-        if (this.manager.get_folder ().get_application ().get_desktop_visibility ()) {
-            debug ("refresh_icon and desktop visibility = true");
-            this.show_all ();
+            this.icon = newImage;
+            this.icon.set_size_request (ICON_WIDTH, ICON_WIDTH);
+            this.icon.get_style_context ().add_class ("df_icon");
+            this.container.pack_start (this.icon, true, true);
+            this.refresh ();
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            Util.show_error_dialog ("Error", e.message);
         }
     }
 
@@ -458,6 +474,24 @@ public class DesktopFolder.ItemView : Gtk.EventBox {
      */
     public bool is_selected () {
         return this.manager.is_selected ();
+    }
+
+    /**
+     * @name fade_in
+     * @description fade the view in. does not call show
+     */
+    public void fade_in () {
+        this.get_style_context ().remove_class ("df_fadeout");
+        this.get_style_context ().add_class ("df_fadein");
+    }
+
+    /**
+     * @name fade_out
+     * @description fade the view out. does not call hide
+     */
+    public void fade_out () {
+        this.get_style_context ().remove_class ("df_fadein");
+        this.get_style_context ().add_class ("df_fadeout");
     }
 
     /**

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -182,6 +182,24 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
     }
 
     /**
+     * @name fade_in
+     * @description fade the view in. does not call show
+     */
+    public void fade_in () {
+        this.get_style_context ().remove_class ("df_fadeout");
+        this.get_style_context ().add_class ("df_fadein");
+    }
+
+    /**
+     * @name fade_out
+     * @description fade the view out. does not call hide
+     */
+    public void fade_out () {
+        this.get_style_context ().remove_class ("df_fadein");
+        this.get_style_context ().add_class ("df_fadeout");
+    }
+
+    /**
      * @name move_to
      * @description move the window to other position
      */
@@ -214,8 +232,7 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
         }
 
         List <unowned string> classes = this.get_style_context ().list_classes ();
-        for (int i = 0; i < classes.length (); i++) {
-            string class = classes.nth_data (i);
+        foreach (string class in classes) {
             if (class.has_prefix ("df_")) {
                 this.get_style_context ().remove_class (class);
             }
@@ -224,6 +241,18 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
         this.get_style_context ().add_class ("df_folder");
         this.get_style_context ().add_class ("df_note");
         this.get_style_context ().add_class ("df_shadow");
+
+        this.get_style_context ().add_class ("df_fadingwindow");
+        if (this.manager.get_application ().get_desktop_visibility ()) {
+            this.get_style_context ().add_class ("df_fadein");
+            // setting opacity to stop the folder window flashing at startup
+            this.opacity = 1;
+        } else {
+            this.get_style_context ().add_class ("df_fadeout");
+            // ditto
+            this.opacity = 0;
+        }
+
         // applying existing colors configuration
         if (settings.bgcolor.has_prefix ("rgb")) {
             string custom = settings.bgcolor;

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -125,6 +125,24 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
     }
 
     /**
+     * @name fade_in
+     * @description fade the view in. does not call show
+     */
+    public void fade_in () {
+        this.get_style_context ().remove_class ("df_fadeout");
+        this.get_style_context ().add_class ("df_fadein");
+    }
+
+    /**
+     * @name fade_out
+     * @description fade the view out. does not call hide
+     */
+    public void fade_out () {
+        this.get_style_context ().remove_class ("df_fadein");
+        this.get_style_context ().add_class ("df_fadeout");
+    }
+
+    /**
      * @name move_to
      * @description move the window to other position
      */
@@ -172,6 +190,17 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
         this.get_style_context ().add_class ("df_photo");
         this.get_style_context ().add_class ("df_transparent");
         this.get_style_context ().add_class ("df_headless");
+
+        this.get_style_context ().add_class ("df_fadingwindow");
+        if (this.manager.get_application ().get_desktop_visibility ()) {
+            this.get_style_context ().add_class ("df_fadein");
+            // setting opacity to stop the folder window flashing at startup
+            this.opacity = 1;
+        } else {
+            this.get_style_context ().add_class ("df_fadeout");
+            // ditto
+            this.opacity = 0;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #100 

- You can now hide and show everything on the desktop by either right clicking the option in the context menu or double clicking the desktop. This is only temporary for the session and not remembered.
- Everything has a fade in and out animation for when you show/hide the desktop
- The app also now fades everything in on launch

Probably this will be the last PR.