### PR TITLE
Tweak panel properties

### DIFF
--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -173,9 +173,13 @@ namespace DesktopFolder.Lang {
     // Managed arrangement
     public const string PANELPROPERTIES_ARRANGEMENT_MANAGED             = _("Let app manage");
     // Default Panel Management
+    public const string PANELPROPERTIES_ICONS                           = _("Icons");
+    // Default Panel Management
     public const string PANELPROPERTIES_ARRANGEMENT_DEFAULT             = _("Default icon arrangement:");
     // Default Panel Arrangement Padding for Items
-    public const string PANELPROPERTIES_ARRANGEMENT_PADDING             = _("Grid spacing:");
+    public const string PANELPROPERTIES_ARRANGEMENT_PADDING             = _("Icon spacing:");
+    // Default Panel Arrangement Padding for Items
+    public const string PANELPROPERTIES_ARRANGEMENT_PADDING_DEFAULT     = _("Default icon spacing:");
 
     // sort by submenu
     public const string DESKTOPFOLDER_MENU_SORT_BY       = _("Sort by");

--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -175,7 +175,7 @@ namespace DesktopFolder.Lang {
     // Default Panel Management
     public const string PANELPROPERTIES_ARRANGEMENT_DEFAULT             = _("Default icon arrangement:");
     // Default Panel Arrangement Padding for Items
-    public const string PANELPROPERTIES_ARRANGEMENT_PADDING             = _("Default Arrangement Padding for Items:");
+    public const string PANELPROPERTIES_ARRANGEMENT_PADDING             = _("Grid spacing:");
 
     // sort by submenu
     public const string DESKTOPFOLDER_MENU_SORT_BY       = _("Sort by");

--- a/src/dialogs/PanelPropertiesWindow.vala
+++ b/src/dialogs/PanelPropertiesWindow.vala
@@ -286,24 +286,27 @@ namespace DesktopFolder.Dialogs {
             resolution_strategy_help.tooltip_text = DesktopFolder.Lang.PANELPROPERTIES_RESOLUTION_STRATEGY_DESCRIPTION;
             general_grid.attach (resolution_strategy_help, 2, 3, 1, 1);
 
+            general_grid.attach (new SettingsHeader (DesktopFolder.Lang.PANELPROPERTIES_ICONS), 0, 4, 2, 1);
+
             // DEFAULT Panel Arrangement
-            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_DEFAULT), 0, 4, 1, 1);
+            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_DEFAULT), 0, 5, 1, 1);
             var arrangement_combo = new Gtk.ComboBoxText ();
             arrangement_combo.append ("FREE", DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_FREE);
             arrangement_combo.append ("GRID", DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_GRID);
             arrangement_combo.append ("MANAGED", DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_MANAGED);
             settings.bind ("default-arrangement", arrangement_combo, "active-id", GLib.SettingsBindFlags.DEFAULT);
             arrangement_combo.margin_end = 8;
-            general_grid.attach (arrangement_combo, 1, 4, 1, 1);
+            general_grid.attach (arrangement_combo, 1, 5, 1, 1);
 
             // DEFAULT Panel Arrangement
-            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_PADDING), 0, 5, 1, 1);
+            general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_PADDING_DEFAULT), 0, 6, 1, 1);
             var scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 50, 1);
             scale.set_value (settings.get_int ("default-arrangement-padding"));
             scale.value_changed.connect (() => {
                 settings.set_int ("default-arrangement-padding", (int) scale.get_value ());
             });
-            general_grid.attach (scale, 1, 5, 1, 1);
+            scale.margin_right = 6;
+            general_grid.attach (scale, 1, 6, 1, 1);
 
             return general_grid;
         }

--- a/src/dialogs/PanelPropertiesWindow.vala
+++ b/src/dialogs/PanelPropertiesWindow.vala
@@ -186,7 +186,7 @@ namespace DesktopFolder.Dialogs {
 
             // the items padding
             general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_PADDING), 0, 7 + top_offset, 1, 1);
-            var scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 50, 1);
+            var scale = new Gtk.SpinButton.with_range (0, 50, 1);
             scale.set_value (this.manager.get_settings ().arrangement_padding);
             scale.value_changed.connect (() => {
                 this.manager.get_settings ().arrangement_padding = (int) scale.get_value ();
@@ -300,12 +300,11 @@ namespace DesktopFolder.Dialogs {
 
             // DEFAULT Panel Arrangement
             general_grid.attach (new SettingsLabel (DesktopFolder.Lang.PANELPROPERTIES_ARRANGEMENT_PADDING_DEFAULT), 0, 6, 1, 1);
-            var scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 50, 1);
+            var scale = new Gtk.SpinButton.with_range (0, 50, 1);
             scale.set_value (settings.get_int ("default-arrangement-padding"));
             scale.value_changed.connect (() => {
                 settings.set_int ("default-arrangement-padding", (int) scale.get_value ());
             });
-            scale.margin_right = 6;
             general_grid.attach (scale, 1, 6, 1, 1);
 
             return general_grid;


### PR DESCRIPTION
- Improve wording
- Use Gtk.SpinButton instead
- Put general icon settings into it's own section
Screenshots:
![image](https://user-images.githubusercontent.com/10395308/48973772-8765c600-f03f-11e8-8637-a2c0bcf30f9d.png)
![image](https://user-images.githubusercontent.com/10395308/48973787-b4b27400-f03f-11e8-8cfa-02020dcc1e46.png)


