### PR TITLE
Fix compilation issues with vala 0.44

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -437,7 +437,7 @@ public class DesktopFolderApp : Gtk.Application {
                 fm.close ();
                 this.folders.remove (fm);
             }
-            this.folders = updated_folder_list.copy ();
+            this.folders = (owned) updated_folder_list;
 
             // finally we close any other not existent note
             while (this.notes.length () > 0) {
@@ -445,7 +445,7 @@ public class DesktopFolderApp : Gtk.Application {
                 nm.close ();
                 this.notes.remove (nm);
             }
-            this.notes = updated_note_list.copy ();
+            this.notes = (owned) updated_note_list;
 
             // finally we close any other not existent photo
             while (this.photos.length () > 0) {
@@ -453,7 +453,7 @@ public class DesktopFolderApp : Gtk.Application {
                 pm.close ();
                 this.photos.remove (pm);
             }
-            this.photos = updated_photo_list.copy ();
+            this.photos = (owned) updated_photo_list;
 
             // by default, we create at least one folder if set by settings
             if (totalFolders == 0 && totalPhotos == 0 && totalNotes == 0 && this.desktop == null) {

--- a/src/settings/PositionSettings.vala
+++ b/src/settings/PositionSettings.vala
@@ -53,7 +53,7 @@ public abstract class DesktopFolder.PositionSettings : Object, Json.Serializable
                 // temporal WEIRD hack to avoid the problem of set an SLIST to the json @value deserializer
                 flag_deserialized = false;
             } else {
-                this._resolutions = value.copy ();
+                this._resolutions = value.copy_deep ((CopyFunc) Object.ref);
             }
             flagChanged = false;
         }
@@ -384,6 +384,15 @@ public abstract class DesktopFolder.PositionSettings : Object, Json.Serializable
         GLib.ObjectClass ocl = (GLib.ObjectClass)type.class_ref ();
         unowned GLib.ParamSpec ? spec = ocl.find_property (name);
         return spec;
+    }
+    public GLib.Value Json.Serializable.get_property (GLib.ParamSpec pspec) {
+        GLib.Value result = GLib.Value (pspec.value_type);
+        base.get_property (pspec.name, ref result);
+        return result;
+    }
+
+    public void Json.Serializable.set_property (GLib.ParamSpec pspec, GLib.Value value) {
+        base.set_property (pspec.name, value);
     }
 
     public Json.Node serialize_property (string property_name, Value @value, ParamSpec pspec) {

--- a/src/utils/dragndrop/DndBehaviour.vala
+++ b/src/utils/dragndrop/DndBehaviour.vala
@@ -162,7 +162,7 @@ namespace DesktopFolder.DragnDrop {
             return selected_files;
         }
 
-        protected unowned GLib.List <File> get_selected_files_for_transfer (GLib.List <unowned File> selection = get_selected_files ()) {
+        protected unowned GLib.List <File> get_selected_files_for_transfer (GLib.List <File> selection = get_selected_files ()) {
             // debug("DndBehaviour-get_selected_files_for_transfer");
             unowned GLib.List <File> list = null;
             list.prepend (this.view.get_file ());

--- a/src/utils/dragndrop/DragNDrop.vala
+++ b/src/utils/dragndrop/DragNDrop.vala
@@ -180,11 +180,11 @@ namespace DesktopFolder.DragnDrop {
                             // it is asked only once, and we cannot unset in the future..
                             // So, we allow copy/move/link and after, it is discarded if it was really the same folder.
                             // TODO, need to be further investigated.
-                            GLib.g_object_unref (parent_file);
+                            parent_file.unref ();
                             suggested_action = Gdk.DragAction.COPY; // Gdk.DragAction.ASK;
                             actions          = Gdk.DragAction.COPY | Gdk.DragAction.MOVE | Gdk.DragAction.LINK; // Gdk.DragAction.ASK|Gdk.DragAction.LINK;
                         } else
-                            GLib.g_object_unref (parent_file);
+                            parent_file.unref ();
                     }
 
                     /* Make these tests at the end so that any changes are not reversed subsequently */


### PR DESCRIPTION
Disco (proposed) has upgraded to vala 0.44 and desktopfolder v1.0.10 no longer builds

Ubuntu Devs have created a patch for that particular version to get it to build under vala 0.44.

This PR is based on that patch rebased for v1.1.0.

So this resolves the compilation issues.

However - important - this just gets the compilation working.  I'm unsure that the changes meet the intention of what the code was originally doing, so please review carefully and advise.