### PR TITLE
Let GSD handle starting/not starting desktopfolder via autostart

### DIFF
--- a/data/com.github.spheras.desktopfolder.desktop.in
+++ b/data/com.github.spheras.desktopfolder.desktop.in
@@ -9,5 +9,7 @@ Type=Application
 NoDisplay=false
 X-GNOME-Autostart-enabled=true
 X-GNOME-Autostart-phase=Running
+AutostartCondition=GSettings com.github.spheras.desktopfolder show-desktopfolder
+X-GNOME-AutoRestart=true
 StartupNotify=false
 Categories=GTK;Utility;


### PR DESCRIPTION
gnome-settings-daemon has the ability to start/stop desktopfolder depending upon the value of a gsettings key.

This PR connects to desktopfolders show-desktop key so that desktops such as budgie can switch desktopfolder on/off