### PR TITLE
Add popup option to open photo in default viewer

### DIFF
--- a/src/logic/PhotoManager.vala
+++ b/src/logic/PhotoManager.vala
@@ -218,6 +218,21 @@ public class DesktopFolder.PhotoManager : Object {
     }
 
     /**
+     * @name open
+     * @description open the photo in the default viewer
+     */
+    public void open () {
+        try {
+            var command = "xdg-open \"" + get_settings ().photo_path + "\"";
+            var appinfo = AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.SUPPORTS_URIS);
+            appinfo.launch_uris (null, null);
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            Util.show_error_dialog ("Error", e.message);
+        }
+    }
+
+    /**
      * @name delete
      * @description delete the file associated
      */

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -309,6 +309,8 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
             } else {
                 this.flag_resizing = true;
             }
+        } else if (event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS) {
+            this.manager.open ();
         }
 
         return false;

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -310,6 +310,7 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
                 this.flag_resizing = true;
             }
         }
+
         return false;
     }
 
@@ -357,7 +358,11 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
             menu.append (new MenuItemSeparator ());
         }
 
-        Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.PHOTO_MENU_DELETE_PHOTO);
+        Gtk.MenuItem item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.ITEM_MENU_OPEN);
+        item.activate.connect ((item) => { this.manager.open (); });
+        menu.append (item);
+
+        item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.PHOTO_MENU_DELETE_PHOTO);
         item.activate.connect ((item) => { this.manager.delete (); });
         menu.append (item);
 


### PR DESCRIPTION
from #277 

This adds a right click option to the photo right click popup to open the photo in the default viewer.

Also called the same routine via a double click on the photo itself