### PR TITLE
Reorganise menu to combine actions

### DIFF
--- a/src/LanguageText.vala
+++ b/src/LanguageText.vala
@@ -61,9 +61,9 @@ namespace DesktopFolder.Lang {
     // desktopfolder menu - create a new empty Text File
     public const string DESKTOPFOLDER_MENU_NEW_EMPTY_FILE        = _("Empty File");
     // desktopfolder menu - rename a Desktop-Folder Pane
-    public const string DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER = _("Rename Panel");
+    public const string DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER = _("Rename");
     // desktopfolder menu - remove a Desktop-Folder Pane
-    public const string DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER = _("Move Panel to Trash");
+    public const string DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER = _("Move to Trash");
     // desktopfolder menu - past from clipboard to the desktop-folder
     public const string DESKTOPFOLDER_MENU_PASTE                 = _("Paste");
     // desktopfolder - The default name for the new folder to be created
@@ -83,7 +83,7 @@ namespace DesktopFolder.Lang {
     // Note - popup option to set allways on back or not
     public const string NOTE_MENU_ON_BACK          = _("Always on back");
     // Menu popup option to rename the note
-    public const string NOTE_MENU_RENAME_NOTE      = _("Rename Note");
+    public const string NOTE_MENU_RENAME_NOTE      = _("Rename");
     // Menu popup option to delete the note
     public const string NOTE_MENU_DELETE_NOTE      = _("Move to Trash");
     // Item Menu - Open the file
@@ -231,5 +231,6 @@ namespace DesktopFolder.Lang {
     public const string DESKTOPFOLDER_MENU_HIDE_DESKTOP  = _("Hide Desktop");
     // Menu option to sort the items vertically
     public const string DESKTOPFOLDER_MENU_SORT_VERTICAL = _("Sort Vertically");
-
+    // Menu color selection dialog
+    public const string MENU_COLOR_DIALOG_TITLE          = _("Select Your Favorite Color");
 }

--- a/src/utils/menu/MenuItemColor.vala
+++ b/src/utils/menu/MenuItemColor.vala
@@ -23,11 +23,9 @@ private class DesktopFolder.MenuItemColor : Gtk.MenuItem {
 
     private string[] tags_colors;
     private string custom;
-    private Gtk.Window window_parent;
     private const int XPAD = 17;
 
-    public MenuItemColor (string[] tags_colors, Gtk.Window window_parent, string ? custom) {
-        this.window_parent = window_parent;
+    public MenuItemColor (string[] tags_colors, string ? custom) {
         this.tags_colors   = tags_colors;
         this.custom        = custom;
         set_size_request (160, 20);

--- a/src/utils/menu/MenuItemColor.vala
+++ b/src/utils/menu/MenuItemColor.vala
@@ -24,6 +24,7 @@ private class DesktopFolder.MenuItemColor : Gtk.MenuItem {
     private string[] tags_colors;
     private string custom;
     private Gtk.Window window_parent;
+    private const int XPAD = 17;
 
     public MenuItemColor (string[] tags_colors, Gtk.Window window_parent, string ? custom) {
         this.window_parent = window_parent;
@@ -55,7 +56,7 @@ private class DesktopFolder.MenuItemColor : Gtk.MenuItem {
         int btnh = 10;
         int y0   = (height - btnh) / 2;
         int x0   = btnw + 5;
-        int xpad = 9;
+        int xpad = XPAD;
 
         if (event.y >= y0 && event.y <= y0 + btnh) {
             for (i = 1; i <= this.tags_colors.length + 1; i++) {
@@ -93,7 +94,7 @@ private class DesktopFolder.MenuItemColor : Gtk.MenuItem {
         int btnh = 10;
         int y0   = (height - btnh) / 2;
         int x0   = btnw + 5;
-        int xpad = 9;
+        int xpad = XPAD;
 
         for (i = 1; i <= this.tags_colors.length + 1; i++) {
             if (i == 1) {

--- a/src/utils/menu/MenuItemColor.vala
+++ b/src/utils/menu/MenuItemColor.vala
@@ -62,7 +62,7 @@ private class DesktopFolder.MenuItemColor : Gtk.MenuItem {
             for (i = 1; i <= this.tags_colors.length + 1; i++) {
                 if (event.x >= xpad + x0 * i && event.x <= xpad + x0 * i + btnw) {
                     if (i > this.tags_colors.length) {
-                        Gtk.ColorSelectionDialog dialog = new Gtk.ColorSelectionDialog ("Select Your Favorite Color");
+                        Gtk.ColorSelectionDialog dialog = new Gtk.ColorSelectionDialog (DesktopFolder.Lang.MENU_COLOR_DIALOG_TITLE);
                         dialog.set_transient_for (this.window_parent);
                         dialog.get_color_selection ().set_has_opacity_control (true);
                         Gdk.RGBA _rgba = Gdk.RGBA ();

--- a/src/utils/menu/MenuItemColor.vala
+++ b/src/utils/menu/MenuItemColor.vala
@@ -63,7 +63,7 @@ private class DesktopFolder.MenuItemColor : Gtk.MenuItem {
                 if (event.x >= xpad + x0 * i && event.x <= xpad + x0 * i + btnw) {
                     if (i > this.tags_colors.length) {
                         Gtk.ColorSelectionDialog dialog = new Gtk.ColorSelectionDialog (DesktopFolder.Lang.MENU_COLOR_DIALOG_TITLE);
-                        dialog.set_transient_for (this.window_parent);
+                        dialog.set_transient_for ((Gtk.Window)this.get_toplevel());
                         dialog.get_color_selection ().set_has_opacity_control (true);
                         Gdk.RGBA _rgba = Gdk.RGBA ();
                         _rgba.parse (this.custom);

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -155,7 +155,7 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         var organize_item        = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_SORT_ORGANIZE);
         // ----------------------------
 
-        var textcolor_item = new MenuItemColor (HEAD_TAGS_COLORS, this, null);
+        var textcolor_item = new MenuItemColor (HEAD_TAGS_COLORS, null);
 
         // Events (please try and keep these in the same order as appended to the menu)
         if (show_icon_options) {

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -253,16 +253,15 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
             context_menu.append (new MenuItemSeparator ());
         }
         context_menu.append (desktop_item);
-        context_menu.append (new MenuItemSeparator ());
         context_menu.append (show_desktop_item);
-        context_menu.append (new MenuItemSeparator ());
+        context_menu.append (openterminal_item);
         context_menu.append (properties_item);
+
         if (show_icon_options) {
             context_menu.append (new MenuItemSeparator ());
             context_menu.append (textcolor_item);
-            context_menu.append (new MenuItemSeparator ());
-            context_menu.append (openterminal_item);
         }
+        
         context_menu.show_all ();
         context_menu.popup_at_pointer (null);
     }

--- a/src/widgets/DesktopWindow.vala
+++ b/src/widgets/DesktopWindow.vala
@@ -255,10 +255,10 @@ public class DesktopFolder.DesktopWindow : DesktopFolder.FolderWindow {
         context_menu.append (desktop_item);
         context_menu.append (show_desktop_item);
         context_menu.append (openterminal_item);
-        context_menu.append (properties_item);
 
         if (show_icon_options) {
             context_menu.append (new MenuItemSeparator ());
+            context_menu.append (properties_item);
             context_menu.append (textcolor_item);
         }
         

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -795,7 +795,9 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         if (this.manager.get_arrangement ().can_organize ()) {
             context_menu.append (organize_item);
         }
-        // -------------------------
+        context_menu.append (new MenuItemSeparator ());
+        context_menu.append (openterminal_item);
+// -------------------------
 
         // context_menu.append (new MenuItemSeparator ());
         // context_menu.append (aligntogrid_item);
@@ -807,11 +809,8 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
         // context_menu.append (lockitems_item);
         // context_menu.append (textshadow_item);
         // context_menu.append (textbold_item);
-        context_menu.append (new MenuItemSeparator ());
         context_menu.append (textcolor_item);
         context_menu.append (backgroundcolor_item);
-        context_menu.append (new MenuItemSeparator ());
-        context_menu.append (openterminal_item);
 
 
         context_menu.show_all ();

--- a/src/widgets/FolderWindow.vala
+++ b/src/widgets/FolderWindow.vala
@@ -706,8 +706,8 @@ public class DesktopFolder.FolderWindow : Gtk.ApplicationWindow {
 
         var trash_item           = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_REMOVE_DESKTOP_FOLDER);
         var rename_item          = new Gtk.MenuItem.with_label (DesktopFolder.Lang.DESKTOPFOLDER_MENU_RENAME_DESKTOP_FOLDER);
-        var textcolor_item       = new MenuItemColor (HEAD_TAGS_COLORS, this, null);
-        var backgroundcolor_item = new MenuItemColor (BODY_TAGS_COLORS, this, this.last_custom_color);
+        var textcolor_item       = new MenuItemColor (HEAD_TAGS_COLORS, null);
+        var backgroundcolor_item = new MenuItemColor (BODY_TAGS_COLORS, this.last_custom_color);
 
         // Events (please try and keep these in the same order as appended to the menu)
         newfolder_item.activate.connect (() => { this.new_folder ((int) event.x, (int) event.y); });

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -553,11 +553,11 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
 
         menu.append (new MenuItemSeparator ());
 
-        item = new MenuItemColor (HEAD_TAGS_COLORS, this, null);
+        item = new MenuItemColor (HEAD_TAGS_COLORS, null);
         ((MenuItemColor) item).color_changed.connect (change_head_color);
         menu.append (item);
 
-        item = new MenuItemColor (BODY_TAGS_COLORS, this, this.last_custom_color);
+        item = new MenuItemColor (BODY_TAGS_COLORS, this.last_custom_color);
         ((MenuItemColor) item).color_changed.connect (change_body_color);
         ((MenuItemColor) item).custom_changed.connect (change_body_color_custom);
         menu.append (item);

--- a/src/widgets/NoteWindow.vala
+++ b/src/widgets/NoteWindow.vala
@@ -545,13 +545,9 @@ public class DesktopFolder.NoteWindow : Gtk.ApplicationWindow {
         item.activate.connect ((item) => { this.manager.trash (); });
         menu.append (item);
 
-        menu.append (new MenuItemSeparator ());
-
         item = new Gtk.MenuItem.with_label (DesktopFolder.Lang.NOTE_MENU_RENAME_NOTE);
         item.activate.connect (this.label.start_editing);
         menu.append (item);
-
-        menu.append (new MenuItemSeparator ());
 
         item = new MenuItemColor (HEAD_TAGS_COLORS, null);
         ((MenuItemColor) item).color_changed.connect (change_head_color);

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -361,8 +361,6 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
         item.activate.connect ((item) => { this.manager.delete (); });
         menu.append (item);
 
-        menu.append (new MenuItemSeparator ());
-
         item = new MenuItemColor (FIXO_TAGS_COLORS, this, null);
         ((MenuItemColor) item).color_changed.connect (change_fixo_color);
         menu.append (item);

--- a/src/widgets/PhotoWindow.vala
+++ b/src/widgets/PhotoWindow.vala
@@ -361,7 +361,7 @@ public class DesktopFolder.PhotoWindow : Gtk.ApplicationWindow {
         item.activate.connect ((item) => { this.manager.delete (); });
         menu.append (item);
 
-        item = new MenuItemColor (FIXO_TAGS_COLORS, this, null);
+        item = new MenuItemColor (FIXO_TAGS_COLORS, null);
         ((MenuItemColor) item).color_changed.connect (change_fixo_color);
         menu.append (item);
 


### PR DESCRIPTION
This PR tidies the right click menu to have "actions" together.

This I feel is more logical - ensures the colours option remains at the bottom to be consistent with other popups and also ensures the previous number of menu separators dont excessively enlarge the menu popup improving its appearance

I've also fixed the padding issue for the custom menuitemcolor so that it is under the text for all themes.  This was tested with a variety of themes to ensure it worked.

![image](https://user-images.githubusercontent.com/996240/65385211-c9c16780-dd23-11e9-9d46-7ddd77a24ce1.png)

I've fixed a crasher for the color dialog on first use.
