### PR TITLE
Fix compilation against Vala 0.46

### DIFF
--- a/src/utils/animation/GtkAnimation.vala
+++ b/src/utils/animation/GtkAnimation.vala
@@ -51,7 +51,7 @@ namespace DesktopFolder.UtilGtkAnimation  {
          * @param {double} duration the duration of the animation
          * @param {AnimateFn} animation_fn the animation function
          */
-        public WidgetAnimation (Gtk.Widget widget, double duration, AnimateFn animation_fn) {
+        protected WidgetAnimation (Gtk.Widget widget, double duration, AnimateFn animation_fn) {
             this._widget       = widget;
             this._animation_fn = animation_fn;
             this._duration     = duration;


### PR DESCRIPTION
In Vala 0.45+, abstract classes can no longer have creation methods which are public. Changing it to protected so it may also be used by sub-classes resolves this issue.