### PR TITLE
Fix the bug of blacked wallpaper on some Linux distros.

### DIFF
--- a/data/css/Application.css
+++ b/data/css/Application.css
@@ -92,6 +92,9 @@ spinner{
 
 /* BODY COLORS */
 /* TRANSPARENT */
+.df_transparent * {
+    background-color: @colorBackgroundTRANSPARENT;
+}
 .df_folder.df_note.window-frame.df_transparent, .df_folder.df_note.window-frame.df_transparent:backdrop,
 .df_folder.df_note.background.df_transparent, .df_folder.df_note.background.df_transparent:backdrop,
 .df_folder.df_note.df_transparent .titlebar, .df_folder.df_note.df_transparent .titlebar:backdrop {


### PR DESCRIPTION
This is a proposed fix for issue #297  . The wallpaper is shown as black seemingly due to an underlying element on top of the wallpaper itself. I didn't go through debugging how come this element exists and wasn't styled -- it doesn't look like there should be an element from the code in the first place -- and since the issue only affects certain distros, I thought a styling workaround would be a good approach.

In short, the styling workaround forces transparency on any descendant of a transparent folder if it doesn't have a styled background.

I tested on my machine, Fedora 32, and the fix looks fine.